### PR TITLE
fix: preserve session files outside .claude during backup

### DIFF
--- a/src/commands/init/internal/backup.rs
+++ b/src/commands/init/internal/backup.rs
@@ -29,7 +29,9 @@ pub fn backup_gitignored_dirs() -> Result<()> {
         let mut preserved_files = Vec::new();
         for file in &session_files_to_preserve {
             if Path::new(file).exists() {
-                let temp_path = format!("{file}.preserve");
+                // Create preserve files OUTSIDE .claude directory
+                let filename = Path::new(file).file_name().unwrap().to_str().unwrap();
+                let temp_path = format!(".{filename}.preserve");
                 fs::copy(file, &temp_path)?;
                 preserved_files.push((file.to_string(), temp_path));
             }
@@ -55,14 +57,14 @@ pub fn restore_session_files() -> Result<()> {
         // Ensure context directory exists
         fs::create_dir_all(".claude/context")?;
 
-        // Restore preserved files
+        // Restore preserved files (they were saved outside .claude)
         let files_to_restore = vec![
             (
-                ".claude/context/active-session.md.preserve",
+                ".active-session.md.preserve",
                 ".claude/context/active-session.md",
             ),
             (
-                ".claude/context/last-session.md.preserve",
+                ".last-session.md.preserve",
                 ".claude/context/last-session.md",
             ),
         ];


### PR DESCRIPTION
## Summary
- Fixed a bug where session files were being preserved inside `.claude` directory before it was moved to backup
- This caused the preserve files to be lost with the backup

## Problem
When running `patina init` on a project with existing `.claude` directory:
1. The backup process tried to preserve session files by copying them with `.preserve` extension
2. But these files were created INSIDE `.claude` directory
3. Then the entire `.claude` directory was moved to backup, taking the preserve files with it
4. The restore process couldn't find the preserve files

## Solution
- Changed backup to create preserve files outside `.claude` directory (as hidden files in project root)
- Updated restore to look for them in the correct location

## Test plan
- [x] Run `cargo fmt --all --check`
- [x] Run `cargo clippy --workspace -- -D warnings` 
- [x] Run `cargo test --workspace`
- [x] Manually tested `patina init .` with existing `.claude` directory