### PR TITLE
Fix: Detect project name from Cargo.toml during re-init

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,14 @@ Patina accumulates knowledge like the protective layer that forms on metal - you
 - Patterns evolve from projects → topics → core
 - Always provide escape hatches
 
+## Testing Guidelines - IMPORTANT
+**Always build release and test with live install:**
+```bash
+cargo build --release                    # Build release binary
+cargo install --path .                   # Install to ~/.cargo/bin
+patina <command>                         # Test with actual installed binary
+```
+
 ## Git Commit Guidelines
 - NEVER add "🤖 Generated with Claude Code" or "Co-Authored-By: Claude" to commit messages
 - Keep commit messages clean and professional without AI attribution


### PR DESCRIPTION
## Summary
- Fixed Issue #26: `patina init .` now uses actual project name from Cargo.toml instead of literal "."
- Added `detect_project_name_from_cargo_toml()` to read package name from Cargo.toml
- Added Testing Guidelines to CLAUDE.md requiring release builds and live installs

## Problem
Running `patina init .` was generating invalid Docker files:
- Dockerfile: `CMD ["."]` instead of `CMD ["patina"]`
- docker-compose.yml: service name `.` instead of `patina`

Root cause: The literal "." was passed directly to Docker template generation.

## Solution
- Created helper function to detect project name from `Cargo.toml` `[package] name` field
- Modified `execute_init()` to use detected name during re-initialization
- Falls back to provided name if Cargo.toml is unavailable

## Changes
- `src/commands/init/internal/mod.rs`: Added project name detection logic
- `CLAUDE.md`: Added Testing Guidelines section

## Test plan
- [x] Build release binary: `cargo build --release`
- [x] Install locally: `cargo install --path .`
- [x] Test `patina init .` generates valid Docker files with `CMD ["patina"]`
- [x] Verify docker-compose.yml has correct service name
- [x] All pre-push checks pass (fmt, clippy, test)
- [x] Issue #26 closed and verified