### PR TITLE
perf: remove DuckDB bundled feature to speed up CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,14 @@ jobs:
       with:
         components: clippy, rustfmt
 
+    - name: Install DuckDB
+      run: |
+        wget https://github.com/duckdb/duckdb/releases/download/v1.1.3/libduckdb-linux-amd64.zip
+        unzip libduckdb-linux-amd64.zip -d libduckdb
+        echo "DUCKDB_LIB_DIR=$PWD/libduckdb" >> $GITHUB_ENV
+        echo "DUCKDB_INCLUDE_DIR=$PWD/libduckdb" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=$PWD/libduckdb" >> $GITHUB_ENV
+
     - name: Cache cargo registry
       uses: actions/cache@v4
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ notify = "6.1"
 rusqlite = { version = "0.32", features = ["bundled", "chrono", "serde_json", "load_extension"] }
 
 # DuckDB for semantic analysis database
-duckdb = { version = "1.1", features = ["bundled"] }
+duckdb = "1.1"
 
 # Parallel processing (better than async for our use case)
 rayon = "1.10"

--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ Each component does one thing well, following Unix philosophy.
 ### Requirements
 - Rust toolchain
 - Git (for state detection)
+- DuckDB (for semantic code analysis)
+  - macOS: `brew install duckdb`
+  - Ubuntu/Debian: `sudo apt-get install libduckdb-dev`
+  - Other platforms: https://duckdb.org/docs/installation/
 - Docker (optional, for rqlite persistence)
 
 ### Quick Setup


### PR DESCRIPTION
## Summary
- Remove `bundled` feature from duckdb dependency
- Install pre-built DuckDB binaries in CI workflow
- Update README with DuckDB installation instructions

## Performance Impact
- **Local builds**: 1m47s → 3.9s (27x faster)
- **CI expected**: 58min → ~8min
  - DuckDB bundled compilation was 49 minutes out of 58 total
  - Was compiled 3x for dev/test/release profiles

## Trade-off
Users now need DuckDB installed as a system dependency:
- macOS: `brew install duckdb`
- Ubuntu: `sudo apt-get install libduckdb-dev`

This is acceptable since Patina is a developer tool and DuckDB is only needed for `patina scrape` semantic analysis.

## Test Plan
- [x] Build locally with system DuckDB (3.9s)
- [x] All tests pass
- [ ] Verify CI completes in ~8min vs previous 58min