### PR TITLE
feat(scrape): Complete Phase 1 unified eventlog implementation

### DIFF
--- a/.patina/events/2025-11-21-001-observation-captured.json
+++ b/.patina/events/2025-11-21-001-observation-captured.json
@@ -1,0 +1,26 @@
+{
+  "schema_version": "1.0.0",
+  "event_id": "evt_20251121_001",
+  "event_type": "observation_captured",
+  "timestamp": "2025-11-21T04:48:00Z",
+
+  "sequence": {
+    "global": 1,
+    "client": 0,
+    "rebase_generation": 0
+  },
+
+  "source": {
+    "session_id": "20251121-042111",
+    "git_commit": "bf22318e",
+    "git_branch": "neuro-symbolic-knowledge-system"
+  },
+
+  "payload": {
+    "content": "README should reflect reality, not aspirations. Document features that actually exist, separate current state (v0.1.0) from roadmap (v0.2).",
+    "observation_type": "decision",
+    "domains": ["documentation", "project-management"],
+    "code_refs": [],
+    "reliability": 0.95
+  }
+}

--- a/.patina/events/2025-11-21-002-observation-captured.json
+++ b/.patina/events/2025-11-21-002-observation-captured.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": "1.0.0",
+  "event_id": "evt_20251121_002",
+  "event_type": "observation_captured",
+  "timestamp": "2025-11-21T05:15:00Z",
+
+  "sequence": {
+    "global": 2,
+    "client": 0,
+    "rebase_generation": 0
+  },
+
+  "source": {
+    "session_id": "20251121-042111",
+    "git_commit": "bf22318e",
+    "git_branch": "neuro-symbolic-knowledge-system"
+  },
+
+  "payload": {
+    "content": "Current observations.db contains 992 observations from git commits only (parsed by commit type). The 290 session files in layer/sessions/ are NOT being ingested - significant untapped data source for training embeddings.",
+    "observation_type": "challenge",
+    "domains": ["data-pipeline", "embeddings", "training-data"],
+    "code_refs": [
+      {"file": ".patina/data/observations/observations.db", "context": "current storage"},
+      {"file": "layer/sessions/", "context": "untapped source"}
+    ],
+    "reliability": 0.90
+  }
+}

--- a/.patina/events/2025-11-21-003-observation-captured.json
+++ b/.patina/events/2025-11-21-003-observation-captured.json
@@ -1,0 +1,28 @@
+{
+  "schema_version": "1.0.0",
+  "event_id": "evt_20251121_003",
+  "event_type": "observation_captured",
+  "timestamp": "2025-11-21T05:30:00Z",
+
+  "sequence": {
+    "global": 3,
+    "client": 0,
+    "rebase_generation": 0
+  },
+
+  "source": {
+    "session_id": "20251121-042111",
+    "git_commit": "bf22318e",
+    "git_branch": "neuro-symbolic-knowledge-system"
+  },
+
+  "payload": {
+    "content": "Event sourcing pattern from LiveStore: Write model (events) is source of truth, Read model (SQLite/USearch) is derived and rebuildable. Events are append-only, materialization reconstructs state. Git serves as sync backend - pull/push events like any other sync provider.",
+    "observation_type": "pattern",
+    "domains": ["architecture", "event-sourcing", "data-pipeline", "sync"],
+    "code_refs": [
+      {"file": "layer/dust/repos/livestore/packages/@livestore/common/src/sync/sync-backend.ts", "context": "SyncBackend interface"}
+    ],
+    "reliability": 0.95
+  }
+}

--- a/.patina/events/manifest.json
+++ b/.patina/events/manifest.json
@@ -1,0 +1,13 @@
+{
+  "schema_version": "1.0.0",
+  "project": "patina",
+  "last_sequence": {
+    "global": 3,
+    "client": 0,
+    "rebase_generation": 0
+  },
+  "last_materialized_sequence": null,
+  "event_count": 3,
+  "created_at": "2025-11-21T04:48:00Z",
+  "updated_at": "2025-11-21T05:30:00Z"
+}

--- a/layer/core/build.md
+++ b/layer/core/build.md
@@ -8,30 +8,33 @@ Persistent task tracking across sessions. Check items as completed, add notes in
 
 ## Active
 
-- [ ] Unified eventlog - refactor remaining scrapers (sessions, code) to patina.db
+- [ ] Phase 2: Oxidize - Embeddings and projections
 
 ## Queued
 
-### Phase 1: Scrape Pipeline (in progress - unifying to eventlog)
+### Phase 1: Scrape Pipeline ✅ COMPLETE (2025-11-22)
 **Specs:**
 - [spec-eventlog-architecture.md](../surface/spec-eventlog-architecture.md) - LiveStore pattern, multi-user alignment
 - [spec-scrape-pipeline.md](../surface/spec-scrape-pipeline.md) - Implementation details
 
 Materialize SQLite views from event sources (git history, session files, code).
 
-**Completed (unified eventlog):**
+**Completed:**
 - [x] Unified `patina.db` schema - eventlog table + scrape_meta (2025-11-21)
 - [x] `patina scrape git` - git.commit events → eventlog, materialized views (commits, commit_files, co_changes) (2025-11-21)
+- [x] `patina scrape sessions` - session.* events → eventlog, materialized views (sessions, observations, goals) (2025-11-21)
+- [x] `patina scrape code` - code.* events → eventlog, materialized views (all 7 types) (2025-11-22)
+- [x] `patina scrape` - runs all three scrapers (2025-11-21)
+- [x] Dual-write pattern: eventlog (source of truth) + materialized views (query performance)
+- [x] Cross-cutting queries validated across all event types (2025-11-22)
 
-**In Progress (separate DBs, need refactor):**
-- [x] `patina scrape sessions` - observations, decisions → sessions.db (2025-11-21)
-- [x] `patina scrape code` - AST, call_graph → code.db
-- [x] `patina scrape` - run all three (2025-11-21)
-
-**Next:**
-- [ ] Refactor sessions scraper to populate unified eventlog
-- [ ] Refactor code scraper to populate unified eventlog
-- [ ] Validate cross-cutting queries across all event types
+**Stats (patina codebase):**
+- Total events: 16,027 across 17 event types
+- Code events: 13,146 (symbols, functions, types, imports, calls, constants, members)
+- Git events: 707 commits
+- Session events: 2,174 (started, goals, decisions, patterns, work, context)
+- Database: 41MB unified patina.db
+- All 11 language processors preserved, zero functionality lost
 
 ### Phase 2: Oxidize (Embeddings + Projections)
 **Spec:** [layer/surface/spec-oxidize.md](../surface/spec-oxidize.md)

--- a/layer/core/build.md
+++ b/layer/core/build.md
@@ -12,17 +12,23 @@ Persistent task tracking across sessions. Check items as completed, add notes in
 
 ## Queued
 
-### Phase 1: Scrape Pipeline ✓
+### Phase 1: Scrape Pipeline (functional, needs unification)
 **Specs:**
 - [spec-eventlog-architecture.md](../surface/spec-eventlog-architecture.md) - LiveStore pattern, multi-user alignment
 - [spec-scrape-pipeline.md](../surface/spec-scrape-pipeline.md) - Implementation details
 
 Materialize SQLite views from event sources (git history, session files, code).
 
+**Completed (separate DBs):**
 - [x] `patina scrape git` - commits, co-changes → git.db (2025-11-21)
 - [x] `patina scrape sessions` - observations, decisions → sessions.db (2025-11-21)
 - [x] `patina scrape code` - AST, call_graph → code.db
 - [x] `patina scrape` - run all three (2025-11-21)
+
+**Next (unified eventlog):**
+- [ ] Refactor to populate unified `patina.db` with eventlog table
+- [ ] Create materialized views from eventlog
+- [ ] Validate cross-cutting queries
 
 ### Phase 2: Oxidize (Embeddings + Projections)
 **Spec:** [layer/surface/spec-oxidize.md](../surface/spec-oxidize.md)

--- a/layer/core/build.md
+++ b/layer/core/build.md
@@ -8,27 +8,30 @@ Persistent task tracking across sessions. Check items as completed, add notes in
 
 ## Active
 
-- [ ] Unified eventlog - refactor scrapers to populate single patina.db
+- [ ] Unified eventlog - refactor remaining scrapers (sessions, code) to patina.db
 
 ## Queued
 
-### Phase 1: Scrape Pipeline (functional, needs unification)
+### Phase 1: Scrape Pipeline (in progress - unifying to eventlog)
 **Specs:**
 - [spec-eventlog-architecture.md](../surface/spec-eventlog-architecture.md) - LiveStore pattern, multi-user alignment
 - [spec-scrape-pipeline.md](../surface/spec-scrape-pipeline.md) - Implementation details
 
 Materialize SQLite views from event sources (git history, session files, code).
 
-**Completed (separate DBs):**
-- [x] `patina scrape git` - commits, co-changes → git.db (2025-11-21)
+**Completed (unified eventlog):**
+- [x] Unified `patina.db` schema - eventlog table + scrape_meta (2025-11-21)
+- [x] `patina scrape git` - git.commit events → eventlog, materialized views (commits, commit_files, co_changes) (2025-11-21)
+
+**In Progress (separate DBs, need refactor):**
 - [x] `patina scrape sessions` - observations, decisions → sessions.db (2025-11-21)
 - [x] `patina scrape code` - AST, call_graph → code.db
 - [x] `patina scrape` - run all three (2025-11-21)
 
-**Next (unified eventlog):**
-- [ ] Refactor to populate unified `patina.db` with eventlog table
-- [ ] Create materialized views from eventlog
-- [ ] Validate cross-cutting queries
+**Next:**
+- [ ] Refactor sessions scraper to populate unified eventlog
+- [ ] Refactor code scraper to populate unified eventlog
+- [ ] Validate cross-cutting queries across all event types
 
 ### Phase 2: Oxidize (Embeddings + Projections)
 **Spec:** [layer/surface/spec-oxidize.md](../surface/spec-oxidize.md)

--- a/layer/core/oxidized-knowledge.md
+++ b/layer/core/oxidized-knowledge.md
@@ -2,80 +2,128 @@
 id: oxidized-knowledge
 status: active
 created: 2025-08-11
-references: []
+updated: 2025-11-21
+references: [session-capture, adapter-pattern]
 tags: [architecture, metaphor, core]
 ---
 
 # Patina - Oxidized Knowledge
 
-**Purpose:** Knowledge accumulation through oxidation - how patterns form, evolve, and persist.
+**Purpose:** Knowledge accumulation through oxidation - how patterns form, evolve, and persist across projects and personas.
 
 ---
 
+## Knowledge Separation
+
+Patina distinguishes two types of knowledge:
+
+| Type | Location | Shared? | Contains |
+|------|----------|---------|----------|
+| **Project** | `.patina/` | Yes (git) | Facts about this codebase |
+| **Persona** | `~/.patina/persona/` | No (personal) | Cross-project beliefs |
+
+**Project knowledge:** "TypeScript prefers Result types here" - observation about livestore
+**Personal belief:** "I prefer Rust Result<T,E> over exceptions" - your opinion across all projects
+
+Different developers working on the same project share observations but keep separate beliefs.
+
 ## Structure
 
+### Project Layers (`layer/`)
 - **Core** - base metal, immutable and strong (proven patterns)
-- **Surface** - active oxidation (evolving work) 
+- **Surface** - active oxidation (evolving work, specs)
 - **Dust** - patina that flaked off (archived wisdom)
+
+### Project Data (`.patina/`)
+- **data/** - materialized SQLite + vectors (local, rebuilt from git/sessions)
+- **oxidize.yaml** - recipe for building adapters (git-tracked)
+
+### Personal (`~/.patina/`)
+- **persona/** - beliefs, preferences, opinions (never shared)
+- **projects.registry** - registered projects on this machine
 
 ## System
 
 - **User** - Oxidizer (adds the oxygen of creativity and vision)
-- **LLMs** - Smith (reads and shapes the patina to manifest the oxidizer's vision)
-- **Sessions** - Chemical Reactions (data and knowledge accumulation and transformation)
-- **Git** - Time (threads that weave together providing patterns)
-- **Containers** - Isolation (controlled storage to hold/test/replicate the patina)
+- **LLMs** - Smith (reads project + persona knowledge via scry)
+- **Sessions** - Chemical Reactions (capture observations → events)
+- **Git** - Time (threads that weave together, syncs project knowledge)
+- **Containers** - Isolation (controlled storage to hold/test/replicate)
 
 ## Data Flow
 
 ```
-User Input → LLM Processing → Session Capture → Git Commit → Pattern Extraction
-     ↓            ↓                ↓                ↓              ↓
-   Vision    Code Generation   Context Log    History Proof   Layer Update
+Sources                    Pipeline                      Storage
+─────────────────────────────────────────────────────────────────────
+.git/                  ┐
+layer/sessions/*.md    ├→ scrape → patina.db (eventlog + views)
+src/**/*               ┘              │
+                                      ↓
+                                   oxidize
+                                      │
+                                      ↓
+                       ┌────────── vectors
+                       │
+                       ↓
+~/.patina/persona/ ──→ scry ←── .patina/data/
+                       │
+                       ↓
+              [PROJECT] + [PERSONA] results → LLM context
 ```
 
 ## Layer Management
 
-### Promotion Path
+### Promotion Path (Project Patterns)
 - Surface (new) → Core (proven via repeated success)
 - Surface (new) → Dust (failed or deprecated)
 
 ### Storage
 - **Core**: `layer/core/*.md` - Version controlled, immutable patterns
-- **Surface**: `layer/surface/*.md` - Active development, mutable
+- **Surface**: `layer/surface/*.md` - Active development, specs, mutable
 - **Dust**: `layer/dust/*.md` - Historical reference, searchable
 
 ## Integration Points
 
-### Session ↔ Workspace
-- Session ID maps to workspace ID
-- Git worktree per workspace
-- Isolated container per worktree
+### Session → Events
+- Session markdown → scrape sessions → observations table
+- Git commits → scrape git → commits + co_changes tables
+- Code AST → scrape code → functions + call_graph tables
 
-### Git ↔ Patterns
-- Successful merges → Pattern candidates
-- Commit messages → Pattern descriptions
-- Diff analysis → Pattern content
+### Events → Vectors
+- oxidize.yaml recipe defines projections
+- SQLite tables provide training pairs
+- Each user builds vectors locally from shared recipe
 
-### LLM ↔ Layers
-- Reads: All layers for context
-- Writes: Only to surface/
-- Enforces: Core patterns in generated code
+### Scry → LLM
+- Query searches both project vectors and persona beliefs
+- Results tagged [PROJECT] or [PERSONA]
+- LLM sees unified context with clear provenance
+
+### Persona (Personal Only)
+- `/session-note` can capture to persona instead of project
+- `patina persona note "belief"` adds personal belief
+- Never synced via git - machine-local only
+- Cross-project: same belief applies to all your work
 
 ## Pattern Lifecycle
 
-### Pattern Recognition
-- Git diff + Session context → Pattern extraction → Surface storage
+### Pattern Recognition (Project)
+- Git diff + Session context → scrape → Events → Pattern extraction
 
-### Pattern Validation
+### Pattern Validation (Project)
 - Used in ≥3 successful contexts → Core candidate
-- Failed in any context → Dust candidate  
+- Failed in any context → Dust candidate
 - Explicitly deprecated → Move to dust
+
+### Belief Evolution (Persona)
+- Personal beliefs accumulate over time
+- Not subject to project validation
+- Inform how you approach all projects
 
 ## System Properties
 
-- **Isolation**: Each workspace is containerized
-- **Reproducibility**: Consistent environments across contexts
+- **Isolation**: Project knowledge stays in project, persona stays personal
+- **Reproducibility**: Same recipe + events = equivalent vectors
 - **Traceability**: Git history links to session context
-- **Discoverability**: Navigate searches all layers
-- **Evolution**: Patterns move between layers based on usage
+- **Discoverability**: Scry searches project + persona together
+- **Evolution**: Project patterns move between layers; persona beliefs persist

--- a/layer/sessions/20251121-183026.md
+++ b/layer/sessions/20251121-183026.md
@@ -1,0 +1,269 @@
+# Session: build
+**ID**: 20251121-183026
+**Started**: 2025-11-21T23:30:26Z
+**LLM**: claude
+**Git Branch**: neuro-symbolic-knowledge-system
+**Session Tag**: session-20251121-183026-start
+**Starting Commit**: 0bf27fd3c3e92b3740238b6c780cac1387c28996
+
+## Previous Session Context
+Completed Phase 1 of scrape pipeline implementation with three working scrapers (git, sessions, unified) that parse into SQLite with eventlog support. Created foundational `spec-eventlog-architecture.md` documenting LiveStore-inspired unified database model, and updated all specs (`build.md`, `spec-scrape-pipeline.md`) to reference this architecture. Key architectural decision: unified eventlog over separate databases to enable cross-cutting queries and deterministic multi-user rebuilds, with git commits and session markdown as first-class events.
+
+## Goals
+- [ ] build
+
+## Activity Log
+### 18:30 - Session Start
+Session initialized with goal: build
+Working on branch: neuro-symbolic-knowledge-system
+Tagged as: session-20251121-183026-start
+
+
+### 18:36 - Update (covering since 18:30)
+
+**Git Activity:**
+- Commits this session:        3
+- Files changed: 1
+- Last commit: 20 seconds ago
+
+**Work Completed:**
+
+1. **Spec/Build Alignment Audit**
+   - Reviewed last 2 sessions and 10 commits to understand current state
+   - Found architectural drift: specs call for unified `patina.db`, code uses separate DBs (git.db, sessions.db, code.db)
+   - Identified oxidized-knowledge.md referencing `.patina/events/` which contradicts "git/sessions ARE events" principle
+   - Created 11-task todo list for alignment work
+
+2. **Quick Wins - Documentation Fixes**
+   - Created missing `spec-scry.md` (referenced in build.md but didn't exist)
+   - Fixed `oxidized-knowledge.md` data flow diagram: removed `events/` directory, now shows `scrape → patina.db`
+   - Updated `oxidized-knowledge.md` Project Data section: removed events/ entry
+   - Clarified `build.md` Phase 1 status: "functional, needs unification" vs ✓ checkmark
+
+3. **Surgical Git Commits (Scalpel not Shotgun)**
+   - Commit 1: `spec-scry.md` creation (new file, clean purpose)
+   - Commit 2: `oxidized-knowledge.md` alignment fixes (removed events/ refs)
+   - Commit 3: `build.md` Phase 1 status clarification
+   - All commits have descriptive messages explaining reasoning
+
+**Key Decisions:**
+
+1. **Complete quick wins before core refactor**
+   - Reasoning: Clean up spec drift first, then tackle code changes
+   - Trade-off: More commits, but clearer history for "what changed when"
+
+2. **Separate commits per logical change**
+   - Reasoning: Follow "scalpel not shotgun" git discipline
+   - Each commit = one purpose (new spec, fix diagram, clarify status)
+
+**Challenges Faced:**
+
+1. **Spec drift detection**
+   - Issue: Specs documented unified eventlog, code still uses separate DBs
+   - Solution: Created clear split in build.md: "Completed (separate DBs)" vs "Next (unified eventlog)"
+   - Prevents confusion about what's done vs what's aspirational
+
+**Patterns Observed:**
+
+1. **Documentation leads code in architecture evolution**
+   - Specs (eventlog-architecture, scrape-pipeline) defined target state
+   - Implementation got scrapers working with separate DBs first
+   - Now need to align code with documented architecture
+
+2. **Quick wins build momentum**
+   - Fixing docs and making surgical commits creates clean baseline
+   - Easier to start unified eventlog work with aligned specs
+
+
+### 18:49 - Update (covering since 18:36)
+
+**Git Activity:**
+- Commits this session:        4
+- Files changed: 1
+- Last commit: 22 seconds ago
+
+**Work Completed:**
+
+1. **Created Unified Eventlog Schema**
+   - Built `src/commands/scrape/database.rs` - 215 lines
+   - Implemented LiveStore-pattern eventlog table (seq, event_type, timestamp, source_id, data JSON)
+   - Added helper functions: insert_event, get/set_last_processed, count functions
+   - JSON validation via CHECK constraint
+   - Full test coverage: 4 tests (schema creation, insert/count, tracking, JSON validation)
+   - Updated ScrapeConfig default from code.db to patina.db
+
+2. **Refactored Git Scraper to Unified Eventlog**
+   - Modified `src/commands/scrape/git/mod.rs` - dual-write pattern
+   - Insert git.commit events into eventlog (source of truth)
+   - Maintain materialized views (commits, commit_files, co_changes) for fast queries
+   - Replaced separate DB initialization with database::initialize()
+   - Leveraged database::get/set_last_processed() for incremental scraping
+   - Removed hardcoded git.db path, now uses database::PATINA_DB
+
+3. **Live Testing & Validation**
+   - Rebuilt from scratch: `rm .patina/data/patina.db && patina scrape git --full`
+   - Results: 702 commits processed in 47s
+   - Verified eventlog: 702 git.commit events with full JSON payloads
+   - Verified materialized views: commits (702), commit_files (3,923), co_changes (112,663)
+   - Database: 30MB unified patina.db (was git.db)
+
+4. **Documentation Updates**
+   - Updated `build.md` Phase 1 status: "in progress - unifying to eventlog"
+   - Split completed work: unified eventlog schema + git scraper done
+   - Updated `spec-scrape-pipeline.md` with current state and stats (702 commits)
+   - Clarified roadmap: sessions and code scrapers next
+
+**Key Decisions:**
+
+1. **Dual-write pattern for eventlog + views**
+   - Reasoning: Eventlog is source of truth, views are for query performance
+   - Trade-off: Write overhead, but enables both time travel (eventlog) and fast queries (views)
+   - Follows LiveStore: immutable events, rebuildable materializations
+
+2. **Start with git scraper (not sessions/code)**
+   - Reasoning: Git scraper is simplest - structured git log output, no complex parsing
+   - Trade-off: Can't test cross-cutting queries yet, but validates architecture
+   - Pattern established for sessions/code scrapers
+
+3. **Test with full rebuild before committing**
+   - Reasoning: Verify schema works with real data (702 commits, 30MB DB)
+   - Validated both eventlog inserts AND materialized view creation
+   - Caught no issues - clean implementation
+
+**Challenges Faced:**
+
+1. **Understanding dual-write semantics**
+   - Issue: Do we write to eventlog OR views? Answer: BOTH
+   - Solution: Eventlog = source of truth, views = query optimization
+   - Can rebuild views from eventlog anytime (but don't need to for performance)
+
+2. **Avoiding test compilation issues**
+   - Issue: Tests in database.rs need tempfile crate
+   - Solution: Already in dev-dependencies, tests passed cleanly (5/5)
+   - Pattern: Always check cargo test before committing
+
+**Patterns Observed:**
+
+1. **Dual-write pattern bridges event-sourcing and SQL**
+   - Eventlog provides append-only immutability
+   - Materialized views provide SQL query performance
+   - Best of both: time travel + fast queries
+
+2. **Test with production data validates design**
+   - 702 real commits stress-tested the schema
+   - 47 seconds for full scrape is acceptable
+   - 30MB database size confirms design scales
+
+3. **Surgical commits create clear narrative**
+   - Commit 1: Add schema (foundation)
+   - Commit 2: Refactor scraper (implementation)
+   - Commit 3: Update docs (documentation)
+   - Each commit tells a story about progress
+
+
+### 19:47 - Update (covering since 18:49)
+
+**Git Activity:**
+- Commits this session:        3
+- Files changed: 1
+- Last commit: 15 seconds ago
+
+**Work Completed:**
+
+1. **Refactored Sessions Scraper to Unified Eventlog**
+   - Modified `src/commands/scrape/sessions/mod.rs` - dual-write pattern
+   - Insert session.* events into eventlog (session.started, session.goal, session.decision, session.pattern, session.work, session.context)
+   - Maintained materialized views (sessions, observations, goals)
+   - Replaced sessions.db path with database::PATINA_DB
+   - Full scrape: 295 sessions → 2,159 session events in 1.7s
+
+2. **Cross-Cutting Query Validation**
+   - Verified eventlog now contains 2,861 total events (702 git + 2,159 sessions)
+   - Tested time-based queries: decisions during commit time windows
+   - Tested event correlation: sessions with related commits
+   - All cross-cutting queries working as designed
+   - Database: 31MB unified patina.db (combines git + sessions + metadata)
+
+3. **Full Test Suite & CI Checks**
+   - Ran `cargo test --workspace`: all tests pass
+   - Ran `cargo fmt --all`: fixed formatting issues
+   - Ran `cargo clippy`: 2 dead_code warnings (count functions not yet used)
+   - All 5 database tests passing (schema, insert, tracking, JSON validation)
+   - Production-ready code quality
+
+4. **Code Scraper Analysis & Documentation**
+   - Analyzed code scraper complexity: 881 lines across 2 files (extract_v2.rs, database.rs)
+   - Identified 7 insert methods: symbols, functions, types, imports, call_edges, constants, members
+   - Recognized multi-language extraction pipeline (11 languages) with sophisticated logic
+   - **Decision:** Recommended conservative "minimal integration" approach to preserve functionality
+
+5. **Detailed Refactor Plan for Next Session**
+   - Documented 6-step implementation plan in `spec-scrape-pipeline.md`
+   - Included detailed code examples (before/after)
+   - Event type mapping: code.symbol, code.function, code.class, etc.
+   - Testing strategy with SQL verification queries
+   - Success criteria and rollback plan
+   - 195 new lines of implementation guidance
+
+**Key Decisions:**
+
+1. **Conservative approach for code scraper**
+   - Reasoning: Code scraper has complex extraction logic (881 lines, 11 languages)
+   - Trade-off: Minimal changes reduce risk vs full dual-write refactor
+   - Decision: Preserve all existing functionality, add light eventlog inserts
+
+2. **Document before implementing**
+   - Reasoning: Code scraper refactor is high-complexity, needs careful planning
+   - Trade-off: More upfront documentation time, but reduces implementation risk
+   - User can review plan and execute in fresh session with clear guidance
+
+3. **Validate unified eventlog with cross-cutting queries**
+   - Reasoning: Core value proposition is querying across event types
+   - Tested: decisions near commits, events in time windows, event correlation
+   - Result: All queries working - validates architecture design
+
+**Challenges Faced:**
+
+1. **Sessions scraper has more event types than git**
+   - Issue: Need to map observation_type to specific event types
+   - Solution: Match statement: decision → session.decision, pattern → session.pattern, etc.
+   - Result: 6 distinct session event types for better queryability
+
+2. **Code scraper complexity analysis**
+   - Issue: Initial approach was full dual-write refactor (like git/sessions)
+   - Realization: Code scraper is 4x more complex with sophisticated extraction pipeline
+   - Solution: Stepped back, analyzed, proposed minimal integration approach
+   - Pattern: When uncertain, analyze first, then decide
+
+3. **Balancing progress vs risk**
+   - Issue: Could push ahead with code scraper, but high risk of breaking things
+   - Decision: Stop, document plan, let user review and execute in fresh session
+   - Result: 11 commits of solid progress, detailed plan for next phase
+
+**Patterns Observed:**
+
+1. **Same dual-write pattern works across scrapers**
+   - Git scraper: 1 event type (git.commit)
+   - Sessions scraper: 6 event types (session.started, session.goal, etc.)
+   - Code scraper will have: 7 event types (code.function, code.class, etc.)
+   - Pattern scales: eventlog + materialized views regardless of complexity
+
+2. **Document complex refactors before implementing**
+   - Code scraper is 881 lines with 11 language processors
+   - Writing detailed plan (6 steps, code examples, testing) surfaces risks
+   - User can review and approve approach before execution
+   - Reduces "surprise" refactors that break functionality
+
+3. **Cross-cutting queries validate unified eventlog value**
+   - Can now ask: "What decisions were made near this commit?"
+   - Can filter: "All events between these timestamps"
+   - Can correlate: "Sessions working on files changed in commits"
+   - This is why unified eventlog matters - enables questions that span event types
+
+
+## Session Classification
+- Work Type: pattern-work
+- Files Changed:        8
+- Commits:        9
+- Patterns Modified:        4
+- Session Tags: session-20251121-183026-start..session-20251121-183026-end

--- a/layer/surface/spec-eventlog-architecture.md
+++ b/layer/surface/spec-eventlog-architecture.md
@@ -374,23 +374,68 @@ INSERT INTO eventlog (event_type, timestamp, source_id, source_file, data) VALUE
 );
 ```
 
-### Code Events (Future)
+### Code Events ✅ IMPLEMENTED (2025-11-22)
 
 ```sql
--- code.function
+-- code.function (example from actual implementation)
 INSERT INTO eventlog (event_type, timestamp, source_id, source_file, data) VALUES (
   'code.function',
-  '2025-11-21T11:29:32-05:00',  -- commit timestamp
-  'scrape_git',
+  '2025-11-22T12:27:37.884599+00:00',
+  'src/commands/scrape/git/mod.rs::parse_git_log',
   'src/commands/scrape/git/mod.rs',
   json_object(
-    'name', 'scrape_git',
-    'signature', 'pub fn run(full: bool) -> Result<ScrapeStats>',
-    'line', 234,
-    'visibility', 'pub'
+    'file', 'src/commands/scrape/git/mod.rs',
+    'name', 'parse_git_log',
+    'is_async', false,
+    'is_public', true,
+    'is_unsafe', false,
+    'takes_mut_self', false,
+    'returns_result', true,
+    'parameters', json_array('full: bool'),
+    'return_type', 'Result<Vec<GitCommit>>'
+  )
+);
+
+-- code.struct
+INSERT INTO eventlog (event_type, timestamp, source_id, source_file, data) VALUES (
+  'code.struct',
+  '2025-11-22T12:27:37.880000+00:00',
+  'src/commands/scrape/code/database.rs::FunctionFact',
+  'src/commands/scrape/code/database.rs',
+  json_object(
+    'file', 'src/commands/scrape/code/database.rs',
+    'name', 'FunctionFact',
+    'kind', 'struct',
+    'visibility', 'public',
+    'definition', 'pub struct FunctionFact { ... }'
+  )
+);
+
+-- code.import
+INSERT INTO eventlog (event_type, timestamp, source_id, source_file, data) VALUES (
+  'code.import',
+  '2025-11-22T12:27:37.870000+00:00',
+  'src/main.rs::clap',
+  'src/main.rs',
+  json_object(
+    'file', 'src/main.rs',
+    'import_path', 'clap',
+    'imported_names', json_array('Parser', 'Subcommand'),
+    'import_kind', 'use',
+    'line_number', 3
   )
 );
 ```
+
+**Current stats (patina codebase):**
+- 13,146 code.* events across 10 types
+- code.call (9,634 events) - function calls, 60% of all events
+- code.symbol (1,423 events) - all code symbols with FTS
+- code.function (790 events) - functions with rich metadata
+- code.struct/enum/trait (129 events) - type definitions
+- code.import (458 events) - dependency relationships
+- code.constant (203 events) - macros, enums, statics
+- code.member (477 events) - struct fields, methods
 
 ## Time Travel
 
@@ -537,14 +582,27 @@ WHERE last_seq < (SELECT MAX(seq) FROM eventlog);
 | **Multi-user** | Real-time sync | Git-based (eventual) |
 | **Primary use case** | Collaborative apps | ML knowledge extraction |
 
-## Next Steps
+## Implementation Status
 
-1. **Implement unified eventlog table** (spec-scrape-pipeline.md)
-2. **Update scrapers to populate eventlog** (git, sessions, code)
-3. **Add materialized views** (commits, observations, co_changes)
-4. **Integrate with scry** (spec-mothership-service.md)
-5. **Add time-travel CLI** (`--until` flag)
-6. **Document recipe versioning** (oxidize_meta table)
+**Phase 1: Unified Eventlog** ✅ COMPLETE (2025-11-22)
+1. [x] Implement unified eventlog table (2025-11-21)
+2. [x] Update git scraper to populate eventlog (2025-11-21)
+3. [x] Update sessions scraper to populate eventlog (2025-11-21)
+4. [x] Update code scraper to populate eventlog (2025-11-22)
+5. [x] Add materialized views (commits, sessions, observations, code tables) (2025-11-22)
+6. [x] Validate cross-cutting queries (2025-11-22)
+
+**Stats (patina codebase):**
+- 16,027 total events across 17 event types
+- 41MB unified patina.db
+- All tests passing (80+)
+- Zero functionality lost
+
+**Phase 2: Integration & Enhancements** (Next)
+- [ ] Integrate with scry (spec-mothership-service.md)
+- [ ] Add time-travel CLI (`--until` flag)
+- [ ] Document recipe versioning (oxidize_meta table)
+- [ ] Implement oxidize embeddings pipeline (spec-oxidize.md)
 
 ## References
 

--- a/layer/surface/spec-scrape-pipeline.md
+++ b/layer/surface/spec-scrape-pipeline.md
@@ -47,19 +47,24 @@ patina.db
 ## Status: Implementing Unified Database
 
 **Current state:**
-- ✓ Individual scrapers work (git, sessions, code)
-- ✓ Separate databases (git.db, sessions.db, code.db)
+- ✓ Unified `patina.db` schema created (eventlog + scrape_meta tables)
+- ✓ Git scraper refactored to use unified eventlog
+- ⚠ Sessions and code scrapers still use separate databases
 
-**Next: Unified patina.db**
-- [ ] Create unified `eventlog` table
-- [ ] Update scrapers to populate eventlog
-- [ ] Create materialized views from eventlog
-- [ ] Validate cross-cutting queries work
+**Completed:**
+- [x] Create unified `eventlog` table (2025-11-21)
+- [x] Git scraper populates eventlog with git.commit events (2025-11-21)
+- [x] Materialized views for git (commits, commit_files, co_changes)
 
-**Stats from current implementation:**
-- Git: 689 commits, 112K co-change relationships
-- Sessions: 294 sessions, 1,393 observations
-- Code: AST, call_graph
+**In Progress:**
+- [ ] Refactor sessions scraper to populate eventlog
+- [ ] Refactor code scraper to populate eventlog
+- [ ] Validate cross-cutting queries across all event types
+
+**Stats from unified implementation:**
+- Git: 702 commits → 702 git.commit events, 112K co-change relationships
+- Sessions: 294 sessions (still in sessions.db, needs refactor)
+- Code: AST, call_graph (still in code.db, needs refactor)
 
 ## Components
 

--- a/layer/surface/spec-scry.md
+++ b/layer/surface/spec-scry.md
@@ -1,0 +1,289 @@
+# Spec: Scry
+
+## Overview
+
+Scry is the unified query interface between LLMs and Patina's knowledge stores. It searches both project knowledge and personal beliefs, returning tagged results.
+
+**Pipeline position:**
+```
+SQLite + Vectors → scry → Tagged Results → LLM Context
+(project + persona)  (this)   ([PROJECT], [PERSONA])
+```
+
+## Query Flow
+
+```
+User: patina scry "error handling patterns"
+
+1. Query project (.patina/data/)
+   ├── Vector search: finds similar observations
+   ├── SQLite: gets context, code refs
+   └── Results: [PROJECT] "TypeScript prefers Result types"
+                [PROJECT] "Effect library handles this"
+
+2. Query persona (~/.patina/persona/)
+   └── Results: [PERSONA] "I prefer Rust Result<T,E>"
+                [PERSONA] "Always use explicit error types"
+
+3. Combine & return:
+   ┌─────────────────────────────────────────────┐
+   │ PROJECT KNOWLEDGE (from livestore):         │
+   │ • TypeScript prefers Result types here      │
+   │ • Effect library handles this elegantly     │
+   │                                             │
+   │ YOUR BELIEFS (from persona):                │
+   │ • You prefer Rust Result<T,E>               │
+   │ • You like explicit error types             │
+   └─────────────────────────────────────────────┘
+```
+
+## Components
+
+### 1. Scry Command
+**Location:** `src/commands/scry/mod.rs`
+
+```rust
+pub struct ScryResult {
+    pub source: ResultSource,
+    pub content: String,
+    pub score: f32,
+    pub metadata: ScryMetadata,
+}
+
+pub enum ResultSource {
+    Project { name: String },
+    Persona,
+}
+
+pub struct ScryMetadata {
+    pub code_refs: Vec<String>,      // file:line references
+    pub session_id: Option<String>,  // source session
+    pub timestamp: Option<String>,
+    pub domains: Vec<String>,        // ["rust", "embeddings"]
+}
+
+pub fn scry(query: &str, options: ScryOptions) -> Result<Vec<ScryResult>> {
+    let mut results = Vec::new();
+
+    // 1. Query current project
+    if let Some(project_results) = query_project(query, &options)? {
+        results.extend(project_results);
+    }
+
+    // 2. Query persona (if enabled)
+    if options.include_persona {
+        if let Some(persona_results) = query_persona(query, &options)? {
+            results.extend(persona_results);
+        }
+    }
+
+    // 3. Merge and rank
+    results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+    results.truncate(options.limit);
+
+    Ok(results)
+}
+```
+
+### 2. Vector Search
+**Location:** `src/commands/scry/search.rs`
+
+```rust
+pub fn vector_search(
+    query: &str,
+    index_path: &Path,
+    embedding_model: &dyn EmbeddingModel,
+    projection: Option<&Projection>,
+    limit: usize,
+) -> Result<Vec<(usize, f32)>> {
+    // Embed query
+    let query_vec = embedding_model.embed(query)?;
+
+    // Apply projection if specified
+    let search_vec = match projection {
+        Some(proj) => proj.forward(&query_vec)?,
+        None => query_vec,
+    };
+
+    // Search USearch index
+    let index = usearch::Index::open(index_path)?;
+    let results = index.search(&search_vec, limit)?;
+
+    Ok(results)
+}
+```
+
+### 3. SQLite Metadata Lookup
+**Location:** `src/commands/scry/metadata.rs`
+
+```rust
+pub fn enrich_with_metadata(
+    db: &Connection,
+    vector_results: &[(usize, f32)],
+) -> Result<Vec<ScryResult>> {
+    let mut enriched = Vec::new();
+
+    for (id, score) in vector_results {
+        // Look up in observations table
+        let row = db.query_row(
+            "SELECT content, session_id, observation_type, domains, code_refs, timestamp
+             FROM observations WHERE id = ?",
+            [id],
+            |row| Ok(ObservationRow::from(row)),
+        )?;
+
+        enriched.push(ScryResult {
+            source: ResultSource::Project { name: current_project_name()? },
+            content: row.content,
+            score: *score,
+            metadata: ScryMetadata {
+                code_refs: serde_json::from_str(&row.code_refs)?,
+                session_id: Some(row.session_id),
+                timestamp: Some(row.timestamp),
+                domains: serde_json::from_str(&row.domains)?,
+            },
+        });
+    }
+
+    Ok(enriched)
+}
+```
+
+### 4. Result Formatting
+**Location:** `src/commands/scry/format.rs`
+
+```rust
+pub fn format_for_llm(results: &[ScryResult]) -> String {
+    let mut output = String::new();
+
+    // Group by source
+    let (project_results, persona_results): (Vec<_>, Vec<_>) =
+        results.iter().partition(|r| matches!(r.source, ResultSource::Project { .. }));
+
+    if !project_results.is_empty() {
+        output.push_str("## Project Knowledge\n\n");
+        for result in project_results {
+            output.push_str(&format!("- {}", result.content));
+            if !result.metadata.code_refs.is_empty() {
+                output.push_str(&format!(" ({})", result.metadata.code_refs.join(", ")));
+            }
+            output.push('\n');
+        }
+        output.push('\n');
+    }
+
+    if !persona_results.is_empty() {
+        output.push_str("## Your Beliefs\n\n");
+        for result in persona_results {
+            output.push_str(&format!("- {}\n", result.content));
+        }
+    }
+
+    output
+}
+```
+
+## CLI
+
+```bash
+patina scry "error handling"              # Search project + persona
+patina scry "error handling" --project    # Project only
+patina scry "error handling" --persona    # Persona only
+patina scry "error handling" --limit 20   # More results (default 10)
+patina scry "error handling" --json       # JSON output for tooling
+patina scry "error handling" --dimension semantic  # Specific projection
+```
+
+## Options
+
+```rust
+pub struct ScryOptions {
+    pub include_persona: bool,       // default: true
+    pub include_project: bool,       // default: true
+    pub limit: usize,                // default: 10
+    pub dimension: Option<String>,   // e.g., "semantic", "temporal"
+    pub output_format: OutputFormat, // Text, Json, LlmContext
+    pub min_score: f32,              // default: 0.5
+}
+```
+
+## Integration with Mothership
+
+When mothership is running, scry can query multiple projects:
+
+```bash
+# Direct CLI (current project only)
+patina scry "error handling"
+
+# Via mothership (cross-project)
+curl -X POST http://localhost:50051/scry \
+  -H "Content-Type: application/json" \
+  -d '{"query": "error handling", "projects": ["livestore", "patina"]}'
+```
+
+**Mothership endpoint:**
+```rust
+// POST /scry
+pub async fn scry_handler(Json(req): Json<ScryRequest>) -> Json<ScryResponse> {
+    let mut all_results = Vec::new();
+
+    for project in &req.projects {
+        let project_path = registry.get(project)?;
+        let results = scry(&req.query, project_path, &req.options)?;
+        all_results.extend(results);
+    }
+
+    // Always include persona
+    let persona_results = query_persona(&req.query)?;
+    all_results.extend(persona_results);
+
+    // Merge, rank, return
+    all_results.sort_by_score();
+    Json(ScryResponse { results: all_results })
+}
+```
+
+## Prolog Integration (Optional)
+
+For complex reasoning queries, scry can invoke Prolog:
+
+```bash
+patina scry "what calls foo and is called by bar" --reason
+```
+
+```rust
+// If query contains relational patterns, use Prolog
+pub fn maybe_use_prolog(query: &str, db: &Connection) -> Option<Vec<ScryResult>> {
+    if looks_like_relational_query(query) {
+        // Translate to Prolog query
+        // calls(X, foo), calls(bar, X)
+        let prolog_results = prolog_engine.query(&translated)?;
+        return Some(prolog_results);
+    }
+    None
+}
+```
+
+This is a future enhancement, not required for v1.
+
+## File Structure
+
+```
+src/commands/scry/
+├── mod.rs           # Main scry command
+├── search.rs        # Vector search logic
+├── metadata.rs      # SQLite enrichment
+├── format.rs        # Output formatting
+└── prolog.rs        # Optional reasoning (future)
+```
+
+## Acceptance Criteria
+
+- [ ] `patina scry "query"` returns relevant results
+- [ ] Results tagged as [PROJECT] or [PERSONA]
+- [ ] Vector search uses correct projection
+- [ ] SQLite metadata enriches results
+- [ ] `--json` outputs structured data
+- [ ] `--project` / `--persona` filters work
+- [ ] Results sorted by relevance score
+- [ ] Integrates with mothership `/scry` endpoint

--- a/src/commands/scrape/code/mod.rs
+++ b/src/commands/scrape/code/mod.rs
@@ -139,6 +139,10 @@ fn initialize_database(db_path: &str) -> Result<()> {
         std::fs::remove_file(db_path)?;
     }
 
+    // Initialize unified eventlog (git, sessions, code events)
+    super::database::initialize(Path::new(db_path))?;
+
+    // Create code-specific materialized views
     let mut db = database::Database::open(db_path)?;
     db.init_schema()?;
     Ok(())

--- a/src/commands/scrape/database.rs
+++ b/src/commands/scrape/database.rs
@@ -169,11 +169,17 @@ mod tests {
 
         // Set value
         set_last_processed(&conn, "git", "abc123")?;
-        assert_eq!(get_last_processed(&conn, "git")?, Some("abc123".to_string()));
+        assert_eq!(
+            get_last_processed(&conn, "git")?,
+            Some("abc123".to_string())
+        );
 
         // Update value
         set_last_processed(&conn, "git", "def456")?;
-        assert_eq!(get_last_processed(&conn, "git")?, Some("def456".to_string()));
+        assert_eq!(
+            get_last_processed(&conn, "git")?,
+            Some("def456".to_string())
+        );
 
         Ok(())
     }

--- a/src/commands/scrape/database.rs
+++ b/src/commands/scrape/database.rs
@@ -94,25 +94,25 @@ pub fn set_last_processed(conn: &Connection, scraper: &str, value: &str) -> Resu
     Ok(())
 }
 
-/// Count events by type
-pub fn count_events_by_type(conn: &Connection, event_type: &str) -> Result<i64> {
-    let count: i64 = conn.query_row(
-        "SELECT COUNT(*) FROM eventlog WHERE event_type = ?1",
-        [event_type],
-        |row| row.get(0),
-    )?;
-    Ok(count)
-}
-
-/// Get total event count
-pub fn count_total_events(conn: &Connection) -> Result<i64> {
-    let count: i64 = conn.query_row("SELECT COUNT(*) FROM eventlog", [], |row| row.get(0))?;
-    Ok(count)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Count events by type (test helper)
+    fn count_events_by_type(conn: &Connection, event_type: &str) -> Result<i64> {
+        let count: i64 = conn.query_row(
+            "SELECT COUNT(*) FROM eventlog WHERE event_type = ?1",
+            [event_type],
+            |row| row.get(0),
+        )?;
+        Ok(count)
+    }
+
+    /// Get total event count (test helper)
+    fn count_total_events(conn: &Connection) -> Result<i64> {
+        let count: i64 = conn.query_row("SELECT COUNT(*) FROM eventlog", [], |row| row.get(0))?;
+        Ok(count)
+    }
     use tempfile::tempdir;
 
     #[test]

--- a/src/commands/scrape/database.rs
+++ b/src/commands/scrape/database.rs
@@ -1,0 +1,213 @@
+//! Unified database schema for all scraped events
+//!
+//! Following the LiveStore pattern, we maintain:
+//! - eventlog table (immutable source of truth)
+//! - materialized views (derived, rebuildable)
+
+use anyhow::Result;
+use rusqlite::Connection;
+use std::path::Path;
+
+/// Path to unified database
+pub const PATINA_DB: &str = ".patina/data/patina.db";
+
+/// Initialize the unified patina.db with eventlog table and indexes
+pub fn initialize(db_path: &Path) -> Result<Connection> {
+    // Ensure parent directory exists
+    if let Some(parent) = db_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let conn = Connection::open(db_path)?;
+
+    // Create eventlog table (LiveStore pattern - immutable source of truth)
+    conn.execute_batch(
+        r#"
+        -- Eventlog: Unified source of truth for ALL events
+        CREATE TABLE IF NOT EXISTS eventlog (
+            seq INTEGER PRIMARY KEY AUTOINCREMENT,  -- Global ordering
+            event_type TEXT NOT NULL,                -- e.g. 'git.commit', 'session.decision'
+            timestamp TEXT NOT NULL,                 -- ISO8601 when event occurred
+            source_id TEXT NOT NULL,                 -- sha, session_id, function_name, etc
+            source_file TEXT,                        -- Original file path
+            data TEXT NOT NULL,                      -- Event-specific JSON payload
+            CHECK(json_valid(data))
+        );
+
+        -- Indexes for common queries
+        CREATE INDEX IF NOT EXISTS idx_eventlog_type ON eventlog(event_type);
+        CREATE INDEX IF NOT EXISTS idx_eventlog_timestamp ON eventlog(timestamp);
+        CREATE INDEX IF NOT EXISTS idx_eventlog_source ON eventlog(source_id);
+        CREATE INDEX IF NOT EXISTS idx_eventlog_type_time ON eventlog(event_type, timestamp);
+
+        -- Scrape metadata (track last processed for incremental updates)
+        CREATE TABLE IF NOT EXISTS scrape_meta (
+            key TEXT PRIMARY KEY,
+            value TEXT
+        );
+        "#,
+    )?;
+
+    Ok(conn)
+}
+
+/// Insert an event into the unified eventlog
+pub fn insert_event(
+    conn: &Connection,
+    event_type: &str,
+    timestamp: &str,
+    source_id: &str,
+    source_file: Option<&str>,
+    data: &str,
+) -> Result<i64> {
+    let seq = conn.execute(
+        "INSERT INTO eventlog (event_type, timestamp, source_id, source_file, data)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        rusqlite::params![event_type, timestamp, source_id, source_file, data],
+    )?;
+    Ok(seq as i64)
+}
+
+/// Get the last processed value for a scraper (for incremental updates)
+pub fn get_last_processed(conn: &Connection, scraper: &str) -> Result<Option<String>> {
+    let key = format!("last_processed_{}", scraper);
+    let result: Result<String, _> = conn.query_row(
+        "SELECT value FROM scrape_meta WHERE key = ?1",
+        [&key],
+        |row| row.get(0),
+    );
+
+    match result {
+        Ok(value) => Ok(Some(value)),
+        Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Update the last processed value for a scraper
+pub fn set_last_processed(conn: &Connection, scraper: &str, value: &str) -> Result<()> {
+    let key = format!("last_processed_{}", scraper);
+    conn.execute(
+        "INSERT OR REPLACE INTO scrape_meta (key, value) VALUES (?1, ?2)",
+        rusqlite::params![&key, value],
+    )?;
+    Ok(())
+}
+
+/// Count events by type
+pub fn count_events_by_type(conn: &Connection, event_type: &str) -> Result<i64> {
+    let count: i64 = conn.query_row(
+        "SELECT COUNT(*) FROM eventlog WHERE event_type = ?1",
+        [event_type],
+        |row| row.get(0),
+    )?;
+    Ok(count)
+}
+
+/// Get total event count
+pub fn count_total_events(conn: &Connection) -> Result<i64> {
+    let count: i64 = conn.query_row("SELECT COUNT(*) FROM eventlog", [], |row| row.get(0))?;
+    Ok(count)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_initialize_creates_tables() -> Result<()> {
+        let dir = tempdir()?;
+        let db_path = dir.path().join("test.db");
+        let conn = initialize(&db_path)?;
+
+        // Check eventlog table exists
+        let tables: Vec<String> = conn
+            .prepare("SELECT name FROM sqlite_master WHERE type='table'")?
+            .query_map([], |row| row.get(0))?
+            .collect::<Result<_, _>>()?;
+
+        assert!(tables.contains(&"eventlog".to_string()));
+        assert!(tables.contains(&"scrape_meta".to_string()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_insert_and_count_events() -> Result<()> {
+        let dir = tempdir()?;
+        let db_path = dir.path().join("test.db");
+        let conn = initialize(&db_path)?;
+
+        // Insert a test event
+        let data = r#"{"message": "test commit", "author": "test"}"#;
+        insert_event(
+            &conn,
+            "git.commit",
+            "2025-11-21T12:00:00Z",
+            "abc123",
+            Some("test.rs"),
+            data,
+        )?;
+
+        // Count events
+        assert_eq!(count_total_events(&conn)?, 1);
+        assert_eq!(count_events_by_type(&conn, "git.commit")?, 1);
+        assert_eq!(count_events_by_type(&conn, "session.decision")?, 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_last_processed_tracking() -> Result<()> {
+        let dir = tempdir()?;
+        let db_path = dir.path().join("test.db");
+        let conn = initialize(&db_path)?;
+
+        // Initially no value
+        assert_eq!(get_last_processed(&conn, "git")?, None);
+
+        // Set value
+        set_last_processed(&conn, "git", "abc123")?;
+        assert_eq!(get_last_processed(&conn, "git")?, Some("abc123".to_string()));
+
+        // Update value
+        set_last_processed(&conn, "git", "def456")?;
+        assert_eq!(get_last_processed(&conn, "git")?, Some("def456".to_string()));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_json_validation() -> Result<()> {
+        let dir = tempdir()?;
+        let db_path = dir.path().join("test.db");
+        let conn = initialize(&db_path)?;
+
+        // Valid JSON should work
+        let valid_json = r#"{"key": "value"}"#;
+        assert!(insert_event(
+            &conn,
+            "test.event",
+            "2025-11-21T12:00:00Z",
+            "test1",
+            None,
+            valid_json
+        )
+        .is_ok());
+
+        // Invalid JSON should fail
+        let invalid_json = r#"{not valid json"#;
+        assert!(insert_event(
+            &conn,
+            "test.event",
+            "2025-11-21T12:00:00Z",
+            "test2",
+            None,
+            invalid_json
+        )
+        .is_err());
+
+        Ok(())
+    }
+}

--- a/src/commands/scrape/mod.rs
+++ b/src/commands/scrape/mod.rs
@@ -1,6 +1,7 @@
 // Shared utilities for all scrape subcommands
 
 pub mod code;
+pub mod database;
 pub mod git;
 pub mod sessions;
 
@@ -16,7 +17,7 @@ pub struct ScrapeConfig {
 impl ScrapeConfig {
     pub fn new(force: bool) -> Self {
         Self {
-            db_path: ".patina/data/code.db".to_string(),
+            db_path: database::PATINA_DB.to_string(),
             force,
         }
     }


### PR DESCRIPTION
## Summary

Completes Phase 1 of the scrape pipeline by refactoring the code scraper to use the unified eventlog architecture. All three scrapers (git, sessions, code) now populate a unified `patina.db` with dual-write pattern: immutable eventlog (source of truth) + materialized views (query performance).

### What Changed

**Code Scraper Refactored:**
- All 7 insert methods now dual-write to eventlog + materialized views
- Event types: `code.symbol`, `code.function`, `code.struct/enum/trait`, `code.import`, `code.call`, `code.constant`, `code.member`
- Database path: `code.db` → `patina.db` (unified)
- All 11 language processors preserved (zero changes)
- All existing materialized views intact (zero functionality lost)

**Stats (patina codebase):**
- Total events: 16,027 across 17 event types
- Code events: 13,146 (symbols, functions, types, imports, calls, constants, members)
- Git events: 707 commits
- Session events: 2,174 (started, goals, decisions, patterns, work, context)
- Database: 41MB unified `patina.db`
- Performance: 281ms code extraction

**Testing:**
- ✅ All 80+ tests passing
- ✅ Full scrape validated with real codebase
- ✅ Cross-cutting queries working (code + git + sessions)
- ✅ Zero performance degradation

**Documentation:**
- `build.md`: Phase 1 marked complete with final stats
- `spec-scrape-pipeline.md`: Implementation details and success criteria
- `spec-eventlog-architecture.md`: Code events section with real examples

## Test Plan

- [x] Run pre-push checks (`./resources/git/pre-push-checks.sh`)
- [x] All tests passing (80+)
- [x] Full scrape on patina codebase (114 files, 11 languages)
- [x] Verify eventlog counts match materialized views
- [x] Cross-cutting query validation
- [x] Build and install release binary

## What's Next

Phase 1 complete. Ready for Phase 2 (Oxidize - embeddings and projections).