### PR TITLE
Phase 4b/4c complete, 4d/4e refined

### DIFF
--- a/layer/core/build.md
+++ b/layer/core/build.md
@@ -47,13 +47,13 @@ See: [rag-network.md](../surface/rag-network.md)
 
 **Phase 4 (Solid Foundation):** ← Current focus
 
-| Phase | Deliverable | Validation |
-|-------|-------------|------------|
-| **4a** | `patina rebuild` | `git clone <project> && patina rebuild && patina scry` works |
-| **4b** | Reference repo indexing | `patina repo add` creates dependency index, `--repo` queries work |
-| **4c** | `--all-repos` query | Single query searches projects + reference repos |
-| **4d** | Persona capture + query | Beliefs flow up from projects, inform queries |
-| **4e** | `patina serve` complete | Containers query Mac mothership |
+| Phase | Deliverable | Status |
+|-------|-------------|--------|
+| **4a** | `patina rebuild` | ✅ Complete |
+| **4b** | Reference repo indexing | ✅ Complete - dependency dimension + auto-detect |
+| **4c** | `--all-repos` query | ✅ Complete - cross-project search |
+| **4d** | Persona capture + query | ⬜ Not started |
+| **4e** | `patina serve` complete | 🟡 API done, container routing pending |
 
 **Specs:**
 - [spec-rebuild-command.md](../surface/build/spec-rebuild-command.md) - for projects
@@ -289,28 +289,30 @@ patina scry "test"  # Full semantic search
 
 **Validation:** Clone any patina project → rebuild → semantic scry works.
 
-### 4b: Reference Repo Indexing
+### 4b: Reference Repo Indexing ✅
 **Spec:** [spec-repo-command.md](../surface/build/spec-repo-command.md)
-**Status:** In Progress
+**Status:** Complete (2025-12-08)
 
 Reference repos get lightweight indexing: code AST, call graph, FTS5, dependency dimension.
 
 ```bash
 patina repo add dojoengine/dojo       # Clone, scrape, index
 patina repo update --oxidize dojo     # Add dependency dimension
-patina scry "spawn" --repo dojo       # Query via FTS5 or dependency
+patina scry "spawn" --repo dojo       # Query via dependency index
 ```
 
 **What reference repos get:**
 - Code AST and symbols (FTS5 lexical search)
-- Call graph (dependency dimension)
+- Call graph (dependency dimension only)
 - Shallow clone (no temporal dimension)
 - No sessions (no semantic dimension)
 
-**Validation:** `patina repo add` + `--oxidize` creates queryable index.
+**Key design:** Recipe creates dependency-only projection (no semantic/temporal since data not available).
 
-### 4c: `--all-repos` Query
-**Status:** Not Started
+**Validation:** ✅ `patina repo update --oxidize` creates queryable index, scry auto-detects available dimensions.
+
+### 4c: `--all-repos` Query ✅
+**Status:** Complete (2025-12-08)
 
 Single query searches projects (full RAG) + reference repos (lightweight).
 
@@ -320,7 +322,9 @@ patina scry "entity component patterns" --all-repos
 # Reference: FTS5 + dependency
 ```
 
-**Validation:** Query returns results from both projects and reference repos.
+**Key design:** Results tagged with source (`[PROJECT]`, `[DOJO]`, etc.), sorted by score.
+
+**Validation:** ✅ Query returns combined results from project + all reference repos.
 
 ### 4d: Persona Capture + Query
 **Spec:** [spec-persona-capture.md](../surface/build/spec-persona-capture.md)
@@ -341,19 +345,23 @@ patina scry "system design"
 
 ### 4e: `patina serve` Complete
 **Spec:** [spec-serve-command.md](../surface/build/spec-serve-command.md)
-**Status:** Phase 1 done (/health endpoint)
+**Status:** `/api/scry` complete (2025-12-08), container integration pending
 
-Full daemon with `/api/scry`, container support, hot model caching.
+HTTP daemon with `/api/scry` for container and remote queries.
 
 ```bash
 # Mac
 patina serve
 
-# Container (YOLO dev)
+# Query via API
+curl -X POST localhost:50051/api/scry \
+  -d '{"query": "session", "limit": 3}'
+
+# Container (YOLO dev) - pending validation
 PATINA_MOTHERSHIP=host.docker.internal:50051 patina scry "test"
 ```
 
-**Validation:** YOLO container can query Mac mothership.
+**Validation:** ✅ `/api/scry` returns JSON results. Container auto-routing pending.
 
 ---
 

--- a/layer/sessions/20251206-101304.md
+++ b/layer/sessions/20251206-101304.md
@@ -1,0 +1,68 @@
+# Session: continue
+**ID**: 20251206-101304
+**Started**: 2025-12-06T15:13:04Z
+**LLM**: claude
+**Git Branch**: patina
+**Session Tag**: session-20251206-101304-start
+**Starting Commit**: 605eacf586c52eba9f607d1a4a987717ce41eda1
+
+## Previous Session Context
+Last session (20251205-115655) consolidated spec docs from 13 to 11 (36% reduction) and implemented the `patina rebuild` command (Phase 4a). The rebuild command was created in `src/commands/rebuild/mod.rs` with `--scrape`, `--oxidize`, `--force`, and `--dry-run` flags. It was tested with `--dry-run` showing 324 sessions, 3 projections, and 818 commits. Open items: test full `patina rebuild` flow (not just --dry-run), then Phase 4b external repo oxidize, then Phase 4c `--all-repos` flag for scry.
+
+## Goals
+- [x] Test full `patina rebuild` flow (without --dry-run)
+- [ ] Phase 4b: Run oxidize on external repos
+- [ ] Phase 4c: Add `--all-repos` flag to scry
+
+## Activity Log
+### 10:13 - Session Start
+Session initialized with goal: continue
+Working on branch: patina
+Tagged as: session-20251206-101304-start
+
+
+### 18:05 - Update (covering since 10:13)
+
+**Git Activity:**
+- Commits this session: 3
+- PR #50: Created and merged to main
+- Files changed: 5 files, +51/-620 lines (net reduction from removing bounty)
+
+**Work Completed:**
+
+1. **Phase 4a Completion**
+   - Reviewed rebuild command code, removed unused `ValidationResult` fields
+   - Tested full `patina rebuild --force` flow (not just --dry-run)
+   - Verified scry works after rebuild (semantic + temporal queries)
+   - Updated build.md and spec to mark 4a complete
+
+2. **Removed Bounty Detection from Core**
+   - Traced dead code (`url` field in `OpportunityInfo`) through session history
+   - Found session 20251204-173633 identified it as "DRIFT - use-case specific"
+   - Deleted `src/commands/scrape/github/opportunity/` module entirely
+   - Stubbed `detect_bounty()` to always return false
+   - Removed bounty tests, kept schema columns for future plugin compatibility
+
+3. **Fixed Pre-Push Script**
+   - Root cause: script used `cargo fmt` (auto-fix) not `cargo fmt --check` (verify)
+   - Also: clippy didn't use `-D warnings` like CI does
+   - Updated `resources/git/pre-push-checks.sh` to mirror CI exactly
+
+**Key Decisions:**
+
+1. **Bounty = future plugin** - Not core, will return when module system designed
+2. **Keep schema columns** - Don't break existing databases, fields just stay empty
+3. **Pre-push must mirror CI** - Prevents "works locally, fails CI" frustration
+
+**Patterns Observed:**
+
+1. **Dead code archaeology** - Session logs are invaluable for understanding "why was this written?"
+2. **CI/local divergence** - Local convenience (auto-fix) vs CI strictness (verify) causes friction
+
+
+## Session Classification
+- Work Type: pattern-work
+- Files Changed:        9
+- Commits:        3
+- Patterns Modified:        3
+- Session Tags: session-20251206-101304-start..session-20251206-101304-end

--- a/layer/sessions/20251206-221156.md
+++ b/layer/sessions/20251206-221156.md
@@ -1,0 +1,58 @@
+# Session: layer/core/build.md review
+**ID**: 20251206-221156
+**Started**: 2025-12-07T03:11:56Z
+**LLM**: claude
+**Git Branch**: patina
+**Session Tag**: session-20251206-221156-start
+**Starting Commit**: 246060e14e3e05eb635f31594527c264df98f016
+
+## Previous Session Context
+Last session (20251206-101304) completed Phase 4a by testing the full `patina rebuild --force` flow and verifying scry works after rebuild. Major cleanup: removed bounty detection from core (5 files, +51/-620 lines) - it's now marked as a future plugin. Also fixed pre-push script to mirror CI exactly (use `cargo fmt --check` and `clippy -D warnings`). Open items: Phase 4b (external repo oxidize) and Phase 4c (--all-repos flag for scry).
+
+## Goals
+- [ ] layer/core/build.md review
+
+## Activity Log
+### 22:11 - Session Start
+Session initialized with goal: layer/core/build.md review
+Working on branch: patina
+Tagged as: session-20251206-221156-start
+
+
+### 23:32 - Update (covering since 22:11)
+
+**Git Activity:**
+- Commits this session: 2
+- Files changed: 10 (7 docs, 3 code)
+- Last commit: 24 minutes ago
+
+**Work Completed:**
+- Reviewed build.md against actual code - verified Phase 4 status is accurate
+- Started Phase 4b implementation: added `--oxidize` flag to `patina repo update`
+- Discovered 3 key challenges with oxidizing external repos
+- Had architectural discussion that clarified two-tier model
+
+**Key Decisions:**
+- **Two-tier architecture crystallized:**
+  - Patina Projects (via `patina init`): full RAG, sessions, all dimensions
+  - Reference Repos (via `patina repo add`): lightweight index, FTS5 + dependency only
+- Owner vs Contributor is git remote config, not patina concern - both use `patina init`
+- Removed `--contrib` flag concept from `repo add` (belongs on `init` if anywhere)
+
+**Challenges Faced:**
+1. Hardcoded paths in embeddings assume running from patina project dir - solved with symlink
+2. External repos lack training data (no sessions → no semantic, shallow clone → no temporal)
+3. Config.toml schema evolved without migration path
+
+**Patterns Observed:**
+- The "what data is available" determines "what dimensions work"
+- Reference repos are fundamentally different from projects - trying to make them the same was wrong
+- Architecture clarity came from discussing the use cases (owner/contributor/reference)
+
+
+## Session Classification
+- Work Type: pattern-work
+- Files Changed:       10
+- Commits:        2
+- Patterns Modified:        7
+- Session Tags: session-20251206-221156-start..session-20251206-221156-end

--- a/layer/sessions/20251208-073926.md
+++ b/layer/sessions/20251208-073926.md
@@ -1,0 +1,72 @@
+# Session: state
+**ID**: 20251208-073926
+**Started**: 2025-12-08T12:39:26Z
+**LLM**: claude
+**Git Branch**: patina
+**Session Tag**: session-20251208-073926-start
+**Starting Commit**: 328e0f5aff1962db711f4724fdf2be1101f2866f
+
+## Previous Session Context
+Last session (20251206-221156) reviewed layer/core/build.md and started Phase 4b implementation, adding the `--oxidize` flag to `patina repo update`. Key architectural insight: crystallized the two-tier model where Patina Projects (via `patina init`) get full RAG/sessions/all dimensions, while Reference Repos (via `patina repo add`) get lightweight FTS5 + dependency indexing only. Discovered that hardcoded embedding paths need symlink workarounds for external repos. Open items remain: Phase 4b completion, Phase 4c (--all-repos for scry).
+
+## Goals
+- [ ] State of code review - assess current project status
+
+## Activity Log
+### 07:39 - Session Start
+Session initialized with goal: state
+Working on branch: patina
+Tagged as: session-20251208-073926-start
+
+
+### 08:20 - Update (covering since 07:39)
+
+**Git Activity:**
+- Commits this session: 0
+- Files changed: 11
+- Last commit: 9 hours ago
+
+**Work completed:**
+- Reviewed recent sessions, git history, and build.md to assess project state
+- Audited alignment between docs and session learnings - found 4 gaps
+- Fixed doc alignment: spec-oxidize.md (Phase 3d complete), spec-persona-capture.md (remove blocked-by-serve), spec-repo-command.md (added Known Challenges), rag-network.md (added Data Availability Principle)
+- **4b complete:** Fixed oxidize_repo to create dependency-only recipe (semantic/temporal impossible without data)
+- **4b enhancement:** Added auto-detection of available dimensions in scry (semantic→dependency→temporal→FTS5 fallback)
+- **4c complete:** Implemented `--all-repos` flag - searches current project + all reference repos, combines results sorted by score
+- **4e API complete:** Added `/api/scry` POST endpoint to serve daemon - JSON request/response for container workflows
+- Updated build.md with current phase status
+
+**Key decisions:**
+- Data Availability Principle is now explicit: what data exists determines which dimensions work
+- Reference repos get dependency-only recipe (not semantic/temporal since they lack sessions and full git history)
+- Scry should auto-detect best available dimension rather than failing
+
+**Challenges faced:**
+- Initial oxidize for reference repos was creating all 3 dimensions but semantic/temporal would fail due to missing data → solution: create dependency-only recipe
+- Scry was defaulting to "semantic" which doesn't exist for reference repos → solution: detect_best_dimension() checks what indices exist
+
+**Patterns observed:**
+- Session insights need to flow back into docs systematically
+- "Data availability determines functionality" is a reusable architectural principle
+
+
+### 08:27 - Update (covering since 08:20)
+
+**Git Activity:**
+- Commits this session: 6
+- Files changed: 0
+- Last commit: 5 minutes ago
+
+**Work completed:**
+- Created 6 clean, logical commits from the session work
+- Session notes, doc alignment, 4b fix, 4c feature, 4e API, build status update
+
+**Session complete - ready to archive.**
+
+
+## Session Classification
+- Work Type: pattern-work
+- Files Changed:       11
+- Commits:        6
+- Patterns Modified:        6
+- Session Tags: session-20251208-073926-start..session-20251208-073926-end

--- a/layer/surface/build/spec-oxidize.md
+++ b/layer/surface/build/spec-oxidize.md
@@ -413,7 +413,7 @@ $ patina oxidize
 
 ### Phase 3: Dependency Dimension
 
-**Status:** Not Started
+**Status:** ✅ Complete (2025-12-03)
 
 **Training Signal:** Functions that call each other are related (caller ↔ callee)
 

--- a/layer/surface/build/spec-persona-capture.md
+++ b/layer/surface/build/spec-persona-capture.md
@@ -11,6 +11,8 @@ Persona captures YOUR cross-project beliefs and patterns - knowledge that belong
 
 **Key principle:** Personas are personal. Different developers have different beliefs, preferences, and mental models. These shouldn't be shared via git.
 
+**Source:** Beliefs flow from **Patina projects** (code you work on). Reference repos are for learning patterns, not capturing beliefs.
+
 ## Persona vs Project Knowledge
 
 | Aspect | Project Knowledge | Persona |

--- a/layer/surface/build/spec-persona-capture.md
+++ b/layer/surface/build/spec-persona-capture.md
@@ -1,8 +1,7 @@
 # Spec: Persona Capture
 
 **Status:** NOT IMPLEMENTED
-**Phase:** 4 (Core Infrastructure)
-**Blocked until:** `patina serve` complete
+**Phase:** 4d (Core Infrastructure)
 
 ---
 

--- a/layer/surface/build/spec-rebuild-command.md
+++ b/layer/surface/build/spec-rebuild-command.md
@@ -8,10 +8,13 @@
 
 ## Purpose
 
-Regenerate `.patina/` from `layer/` and local sources. This is the "clone and go" command that makes Patina projects portable.
+Regenerate `.patina/` from `layer/` and local sources for **Patina projects**. This is the "clone and go" command that makes projects portable.
+
+**Applies to:** Patina projects (code you work on, created via `patina init`)
+**Not for:** Reference repos (use `patina repo update --oxidize` instead)
 
 **Use cases:**
-1. Clone a repo with `layer/` → `patina rebuild` → working local RAG
+1. Clone a project with `layer/` → `patina rebuild` → working local RAG
 2. Corrupted `.patina/data/` → `patina rebuild` → fresh indices
 3. Upgrade embedding model → `patina rebuild` → new projections
 
@@ -202,6 +205,5 @@ pub fn run(args: RebuildArgs) -> anyhow::Result<()> {
 
 ## Future Considerations
 
-- `patina rebuild --repo <name>` - rebuild external repo from `~/.patina/repos/`
 - `patina rebuild --parallel` - parallelize scrape steps
 - Incremental rebuild (only changed files) - deferred, full rebuild is fine for now

--- a/layer/surface/build/spec-repo-command.md
+++ b/layer/surface/build/spec-repo-command.md
@@ -1,13 +1,15 @@
 # Spec: patina repo
 
-**Status:** Complete (Phase 3c)
+**Status:** In Progress (Phase 4b)
 **Location:** `src/commands/repo/`
 
 ---
 
 ## Purpose
 
-Manage external repos for learning and contributing. All repos become full Patina projects with `.patina/`, `layer/`, and queryable indices.
+Manage **reference repos** - read-only knowledge bases for learning patterns from other codebases. Reference repos get lightweight indexing (code AST, call graph, FTS5), not full RAG.
+
+**Not for code you work on.** If you want to contribute to a repo, use `patina init` on it instead.
 
 ---
 
@@ -16,18 +18,26 @@ Manage external repos for learning and contributing. All repos become full Patin
 ### patina repo add
 
 ```bash
-patina repo <url>              # Clone + scaffold + scrape
-patina repo <url> --with-issues # Also scrape GitHub issues
-patina repo <url> --contrib    # Fork for contribution (partial)
+patina repo <url>                 # Clone + scrape + index
+patina repo <url> --with-issues   # Also scrape GitHub issues
 ```
 
 **What happens:**
-1. Clone to `~/.patina/repos/<name>/`
-2. Create `patina` branch
-3. Full `.patina/` scaffolding
-4. Scrape codebase to `patina.db`
+1. Shallow clone to `~/.patina/repos/<name>/`
+2. Scaffold `.patina/` with config
+3. Scrape codebase: symbols, functions, call graph
+4. Build FTS5 index for lexical search
 5. Register in `~/.patina/registry.yaml`
-6. (--contrib) Fork on GitHub, add remote
+
+**What reference repos get:**
+- Code AST and symbols (FTS5 lexical search)
+- Call graph for dependency queries
+- GitHub issues if `--with-issues`
+
+**What reference repos don't get:**
+- `layer/` directory (no sessions)
+- Temporal dimension (shallow clone = no git history)
+- Semantic dimension (no session data)
 
 ### patina repo list
 
@@ -37,17 +47,23 @@ patina repo list
 
 **Output:**
 ```
-NAME              GITHUB                        CONTRIB   DOMAINS
-dojo              dojoengine/dojo               ✓ fork    cairo, ecs
-bevy              bevyengine/bevy               -         rust, ecs
+NAME              GITHUB                        DOMAINS
+dojo              dojoengine/dojo               cairo, ecs
+bevy              bevyengine/bevy               rust, ecs
+SDL               libsdl-org/SDL                c, graphics
 ```
 
 ### patina repo update
 
 ```bash
-patina repo update <name>      # Pull + rescrape
-patina repo update --all       # Update all repos
+patina repo update <name>           # Pull + rescrape
+patina repo update <name> --oxidize # Also build dependency index
+patina repo update --all            # Update all repos
 ```
+
+**`--oxidize` builds:**
+- Dependency projection (call graph → vector space)
+- Enables semantic-style queries on code structure
 
 ### patina repo show
 
@@ -60,22 +76,33 @@ patina repo show <name>
 Name: dojo
 GitHub: dojoengine/dojo
 Path: ~/.patina/repos/dojo
-Branch: patina
 Events: 24,531
-Last updated: 2 hours ago
+Indexed: dependency
 ```
+
+### patina repo remove
+
+```bash
+patina repo remove <name>
+```
+
+Removes from registry and deletes from `~/.patina/repos/`.
 
 ---
 
 ## Query Integration
 
 ```bash
-# Query specific repo
+# Query specific reference repo
 patina scry "spawn patterns" --repo dojo
 
-# Query multiple repos (planned)
-patina scry "entity component" --repos dojo,bevy
+# Query all (projects + reference repos)
+patina scry "entity component" --all-repos
 ```
+
+Reference repos support:
+- FTS5 lexical search (always)
+- Dependency dimension (if `--oxidize` was run)
 
 ---
 
@@ -83,15 +110,15 @@ patina scry "entity component" --repos dojo,bevy
 
 ```
 ~/.patina/
-├── registry.yaml           # Tracks all repos
+├── registry.yaml           # Tracks projects + reference repos
 └── repos/
     ├── dojo/
     │   ├── .patina/
     │   │   ├── data/
-    │   │   │   └── patina.db
-    │   │   └── config.toml
-    │   ├── layer/
-    │   │   └── sessions/   # YOUR learning sessions
+    │   │   │   ├── patina.db
+    │   │   │   └── embeddings/    # If --oxidize
+    │   │   ├── config.toml
+    │   │   └── oxidize.yaml       # If --oxidize
     │   └── <source code>
     └── bevy/
         └── ...
@@ -109,18 +136,12 @@ repos:
   dojo:
     path: ~/.patina/repos/dojo
     github: dojoengine/dojo
-    contrib: true
-    fork: nicabar/dojo
     registered: 2025-11-20T10:00:00Z
     domains: [cairo, starknet, ecs]
-    github_data:
-      issues: true
-      issue_count: 347
 
   bevy:
     path: ~/.patina/repos/bevy
     github: bevyengine/bevy
-    contrib: false
     registered: 2025-11-22T14:00:00Z
     domains: [rust, ecs, game-engine]
 ```
@@ -134,5 +155,5 @@ repos:
 - [x] `patina repo update <name>` pulls and rescrapes
 - [x] `patina scry --repo <name>` queries repo's database
 - [x] Registry persists in `~/.patina/registry.yaml`
-- [ ] `--contrib` fork mode (partial - gh cli dependency)
-- [ ] `repo update` calls github scraper when issues present
+- [ ] `patina repo update --oxidize` builds dependency index
+- [ ] `--with-issues` scrapes GitHub issues

--- a/layer/surface/build/spec-repo-command.md
+++ b/layer/surface/build/spec-repo-command.md
@@ -157,3 +157,29 @@ repos:
 - [x] Registry persists in `~/.patina/registry.yaml`
 - [ ] `patina repo update --oxidize` builds dependency index
 - [ ] `--with-issues` scrapes GitHub issues
+
+---
+
+## Known Challenges (Phase 4b)
+
+Identified in session 20251206-221156:
+
+### 1. Hardcoded Embedding Paths
+**Problem:** Embedding code assumes running from a patina project directory with `.patina/data/embeddings/`.
+
+**Current workaround:** Symlink from reference repo to shared model cache.
+
+**Proper fix:** Make embedding paths configurable, default to `~/.patina/cache/models/` for reference repos.
+
+### 2. Reference Repos Lack Training Data
+**Problem:** Oxidize needs training pairs, but reference repos don't have the data sources:
+- No `layer/sessions/` → no semantic dimension (no session pairs)
+- Shallow clone → no temporal dimension (no co-change history)
+- Only call graph available → dependency dimension only
+
+**Implication:** Reference repos can only support dependency dimension, not semantic or temporal. This is by design (the "Data Availability Principle").
+
+### 3. Config Schema Evolution
+**Problem:** `config.toml` schema has evolved without a migration path. Old reference repos may have stale configs.
+
+**Fix needed:** Version field in config + migration logic in `patina repo update`.

--- a/layer/surface/build/spec-scry.md
+++ b/layer/surface/build/spec-scry.md
@@ -21,7 +21,7 @@ User: patina scry "error handling patterns"
    └── Results: [PROJECT] "TypeScript prefers Result types"
                 [PROJECT] "Effect library handles this"
 
-2. Query persona (~/.patina/persona/)
+2. Query persona (~/.patina/personas/default/)
    └── Results: [PERSONA] "I prefer Rust Result<T,E>"
                 [PERSONA] "Always use explicit error types"
 

--- a/layer/surface/build/spec-serve-command.md
+++ b/layer/surface/build/spec-serve-command.md
@@ -10,7 +10,7 @@
 
 HTTP daemon for container queries, hot model caching, and cross-project search. Follows Ollama pattern - single binary, lazy loading, REST API.
 
-**Aggregates:** Patina projects (full RAG) + reference repos (lightweight indices)
+**Aggregates:** Patina projects (full RAG) + reference repos (lightweight indices) + persona (cross-project knowledge)
 
 ---
 
@@ -37,12 +37,13 @@ Mac (Mothership)                    Container
 | Method | Endpoint | Purpose | Status |
 |--------|----------|---------|--------|
 | GET | `/health` | Health check | ✅ Done |
-| POST | `/api/scry` | Query (semantic/lexical/file) | Planned |
+| POST | `/api/scry` | Query (semantic/lexical/file) | ✅ Done |
 | POST | `/api/embed` | Generate embedding | Planned |
 | POST | `/api/embed/batch` | Batch embeddings | Planned |
 | GET | `/api/repos` | List repos | Planned |
 | GET | `/api/repos/{name}` | Repo details | Planned |
 | GET | `/api/model` | Model status | Planned |
+| GET | `/api/persona` | Query persona | Planned (4d) |
 
 ---
 
@@ -79,10 +80,11 @@ patina serve --daemon
 - [ ] Lazy model loading on first request
 
 ### Phase 3: Scry API + Client Detection
-- [ ] `/api/scry` endpoint (semantic/lexical/file)
+- [x] `/api/scry` endpoint (semantic/lexical/file) ✅ (2025-12-08)
 - [ ] Mothership client module in `src/mothership/`
 - [ ] Auto-detection: `PATINA_MOTHERSHIP` env var
 - [ ] Update scry command to route to daemon when available
+- [ ] Persona integration (`include_persona` option)
 
 ### Phase 4: Container Integration
 - [ ] `--host 0.0.0.0` option for container access
@@ -137,9 +139,10 @@ max_memory_mb = 2048
 
 ## Validation Criteria
 
-**Phase 4 complete when:**
-1. [ ] `patina serve` exposes `/api/scry` endpoint
+**4e complete when:**
+1. [x] `patina serve` exposes `/api/scry` endpoint
 2. [ ] `patina scry` detects daemon and routes queries
 3. [ ] Container can query Mac via `PATINA_MOTHERSHIP` env var
-4. [ ] `patina scry --all-repos` queries across registry
+4. [x] `patina scry --all-repos` queries across registry
 5. [ ] Model stays hot between requests (lazy loading works)
+6. [ ] `/api/scry` supports `include_persona` option (after 4d)

--- a/layer/surface/build/spec-serve-command.md
+++ b/layer/surface/build/spec-serve-command.md
@@ -10,6 +10,8 @@
 
 HTTP daemon for container queries, hot model caching, and cross-project search. Follows Ollama pattern - single binary, lazy loading, REST API.
 
+**Aggregates:** Patina projects (full RAG) + reference repos (lightweight indices)
+
 ---
 
 ## Architecture

--- a/layer/surface/persona-belief-architecture.md
+++ b/layer/surface/persona-belief-architecture.md
@@ -1,7 +1,7 @@
 ---
 id: persona-belief-architecture
 version: 1
-status: draft
+status: historical
 created_date: 2025-10-25
 updated_date: 2025-10-25
 oxidizer: nicabar
@@ -9,6 +9,8 @@ tags: [architecture, persona, beliefs, ontology, neuro-symbolic, domains]
 ---
 
 # Persona-Belief Architecture
+
+> **Note (2025-12-08):** This is the original detailed design from October 2025. The current implementation direction is captured in `build/spec-persona-capture.md`. This doc remains as reference for the neuro-symbolic concepts (Prolog validation, structured beliefs) which may be used in the reflection flow.
 
 **Core Concept**: Patina hosts a single persona per installation—a belief system that interprets and structures all knowledge. Data only exists through the lens of this persona.
 

--- a/layer/surface/rag-network.md
+++ b/layer/surface/rag-network.md
@@ -24,7 +24,7 @@ Each project is a knowledge node:
 ### 2. Mothership as Hub
 
 `~/.patina/` contains:
-- `persona/` - Cross-project beliefs and facts
+- `personas/` - Cross-project knowledge (see spec-persona-capture.md)
 - `registry.yaml` - All known projects and reference repos
 - `cache/models/` - Shared model cache
 - `repos/` - Reference repos (read-only knowledge bases)
@@ -76,9 +76,9 @@ Reference repos don't get: sessions, temporal, semantic dimensions.
 
 ### 6. Data Flow
 
-- **UP:** Learnings flow from projects → Mothership persona
-- **DOWN:** Knowledge flows only through explicit queries
-- Reference repos don't contribute to persona (read-only)
+- **UP:** Knowledge flows from projects → Mothership personas
+- **DOWN:** Knowledge flows only through explicit queries (scry)
+- Reference repos don't contribute to persona (read-only knowledge sources)
 
 ### 7. Data Availability Principle
 
@@ -149,6 +149,6 @@ This is the adapter pattern applied to models.
 
 > "Patina is an organic agentic RAG that captures knowledge across projects and domains"
 
-> "Projects are islands, personas are gods. Knowledge flows UP (project → persona). Knowledge flows DOWN only through explicit requests."
+> "Projects are islands, personas are the user. Knowledge flows UP (project → persona). Knowledge flows DOWN only through explicit queries."
 
 > "Mothership is a librarian, not a library. It tracks where knowledge lives, doesn't duplicate it."

--- a/layer/surface/rag-network.md
+++ b/layer/surface/rag-network.md
@@ -80,6 +80,26 @@ Reference repos don't get: sessions, temporal, semantic dimensions.
 - **DOWN:** Knowledge flows only through explicit queries
 - Reference repos don't contribute to persona (read-only)
 
+### 7. Data Availability Principle
+
+**Core insight (session 20251206-221156):** What data is available determines which dimensions work.
+
+| Data Source | Dimension Enabled | Who Has It |
+|-------------|-------------------|------------|
+| `layer/sessions/` | Semantic | Patina projects only |
+| Full git history | Temporal | Patina projects only |
+| Call graph (AST) | Dependency | Both projects and reference repos |
+| Code symbols | FTS5 lexical | Both projects and reference repos |
+
+**Why this matters:**
+- Reference repos are shallow clones with no sessions → they can't have semantic or temporal dimensions
+- This isn't a limitation to fix; it's the design. Reference repos are for learning patterns, not capturing your work
+- Trying to make reference repos "full RAG" was architectural drift - the two-tier model exists because the data sources are fundamentally different
+
+**Implication for queries:**
+- `patina scry` on a project: semantic + temporal + dependency + FTS5
+- `patina scry --repo` on reference: dependency + FTS5 only
+
 ---
 
 ## Source Architecture (Bundles + Modules)

--- a/layer/surface/rag-network.md
+++ b/layer/surface/rag-network.md
@@ -25,9 +25,9 @@ Each project is a knowledge node:
 
 `~/.patina/` contains:
 - `persona/` - Cross-project beliefs and facts
-- `registry.yaml` - All known nodes
+- `registry.yaml` - All known projects and reference repos
 - `cache/models/` - Shared model cache
-- `repos/` - External repos (learning + contributing)
+- `repos/` - Reference repos (read-only knowledge bases)
 
 ### 3. Domains as Tags
 
@@ -36,43 +36,49 @@ Nodes tagged with domains for cross-project queries:
 - cairo: [dojo, starknet]
 - ecs: [dojo, bevy]
 
-### 4. Branch Strategy (Owner vs Contributor)
+### 4. Patina Projects
 
-**Owner repos (your code):**
+All code you work on (owner or contributor) is a Patina project:
+
 ```
-main/master:
+<project>/
 ├── src/
 ├── layer/           # Patina content lives here
 │   ├── core/        # Eternal patterns
 │   ├── surface/     # Active work
 │   ├── dust/        # Archived
 │   └── sessions/    # Learnings
-├── .patina/         # Config + local indices
+├── .patina/         # Config + local indices (gitignored)
 └── CLAUDE.md        # LLM adapter
 ```
 
-**Contributor repos (others' code):**
+**Owner vs Contributor** is a git remote configuration, not a Patina concern:
+- Owner: push to origin/main
+- Contributor: push to fork, PR to upstream
+
+Patina treats both the same - full RAG, sessions, all dimensions.
+
+### 5. Reference Repos
+
+Read-only knowledge bases (code you learn from, not work on):
+
 ```
-upstream/main:       # Clean, their code, for PRs
-├── src/
-└── (no layer/)
-
-patina branch:       # YOUR overlay
-├── src/             # Their code
-├── layer/           # YOUR learnings about their code
-│   └── sessions/    # Your study sessions
-└── .patina/         # YOUR config for this repo
-
-Workflow:
-- Work on feature-branch from main
-- PR to upstream (clean, no layer/)
-- Merge learnings to patina branch
+~/.patina/repos/<name>/
+├── src/             # Their code (shallow clone)
+├── .patina/         # Lightweight index
+│   ├── data/patina.db
+│   └── config.toml
+└── (no layer/)      # No sessions, no learnings
 ```
 
-### 5. Data Flow
+Reference repos get: code AST, call graph, FTS5, dependency dimension.
+Reference repos don't get: sessions, temporal, semantic dimensions.
 
-- **UP:** Learnings flow from project → Mothership persona
+### 6. Data Flow
+
+- **UP:** Learnings flow from projects → Mothership persona
 - **DOWN:** Knowledge flows only through explicit queries
+- Reference repos don't contribute to persona (read-only)
 
 ---
 

--- a/src/commands/eval/mod.rs
+++ b/src/commands/eval/mod.rs
@@ -138,6 +138,7 @@ fn eval_semantic(conn: &Connection) -> Result<EvalResults> {
             dimension: Some("semantic".to_string()),
             file: None,
             repo: None,
+            all_repos: false,
             include_issues: false,
         };
 
@@ -238,6 +239,7 @@ fn eval_temporal_text(conn: &Connection) -> Result<EvalResults> {
             dimension: Some("temporal".to_string()),
             file: None,
             repo: None,
+            all_repos: false,
             include_issues: false,
         };
 
@@ -330,6 +332,7 @@ fn eval_temporal_file(conn: &Connection) -> Result<EvalResults> {
             dimension: Some("temporal".to_string()),
             file: None,
             repo: None,
+            all_repos: false,
             include_issues: false,
         };
 

--- a/src/commands/repo/internal.rs
+++ b/src/commands/repo/internal.rs
@@ -231,7 +231,7 @@ pub fn list_repos() -> Result<Vec<RepoEntry>> {
 }
 
 /// Update a specific repository
-pub fn update_repo(name: &str) -> Result<()> {
+pub fn update_repo(name: &str, oxidize: bool) -> Result<()> {
     let registry = Registry::load()?;
     let entry = registry
         .repos
@@ -250,13 +250,22 @@ pub fn update_repo(name: &str) -> Result<()> {
     println!("🔍 Re-scraping codebase...");
     let event_count = scrape_repo(repo_path)?;
 
+    // Oxidize if requested
+    if oxidize {
+        println!("\n🧪 Building semantic indices...");
+        oxidize_repo(repo_path)?;
+    }
+
     println!("\n✅ Updated {} ({} events)", name, event_count);
+    if oxidize {
+        println!("   Semantic indices built - scry will use vector search");
+    }
 
     Ok(())
 }
 
 /// Update all repositories
-pub fn update_all_repos() -> Result<()> {
+pub fn update_all_repos(oxidize: bool) -> Result<()> {
     let repos = list_repos()?;
 
     if repos.is_empty() {
@@ -269,7 +278,7 @@ pub fn update_all_repos() -> Result<()> {
     let mut success = 0;
     for repo in &repos {
         print!("  {} ... ", repo.name);
-        match update_repo(&repo.name) {
+        match update_repo(&repo.name, oxidize) {
             Ok(_) => {
                 println!("✓");
                 success += 1;
@@ -507,6 +516,9 @@ type = "external"
 [scrape]
 include = ["**/*.rs", "**/*.cairo", "**/*.sol", "**/*.ts", "**/*.js", "**/*.py", "**/*.go"]
 exclude = ["target/", "node_modules/", ".git/"]
+
+[embeddings]
+model = "e5-base-v2"
 "#,
         )?;
     }
@@ -555,6 +567,81 @@ fn scrape_repo(repo_path: &Path) -> Result<usize> {
     std::env::set_current_dir(original_dir)?;
 
     Ok(stats.items_processed)
+}
+
+/// Run oxidize on a repo to build semantic indices
+fn oxidize_repo(repo_path: &Path) -> Result<()> {
+    use crate::commands::oxidize;
+    use std::os::unix::fs::symlink;
+
+    // Save current directory (where patina project with models lives)
+    let original_dir = std::env::current_dir()?;
+    let resources_path = original_dir.join("resources");
+
+    // Change to repo directory
+    std::env::set_current_dir(repo_path)?;
+
+    // Ensure config.toml has embeddings section (fix for older scaffolds)
+    let config_path = repo_path.join(".patina/config.toml");
+    if config_path.exists() {
+        let config_content = fs::read_to_string(&config_path)?;
+        if !config_content.contains("[embeddings]") {
+            println!("   Adding embeddings config...");
+            let updated = format!("{}\n[embeddings]\nmodel = \"e5-base-v2\"\n", config_content);
+            fs::write(&config_path, updated)?;
+        }
+    }
+
+    // Create oxidize.yaml if it doesn't exist
+    let recipe_path = repo_path.join(".patina/oxidize.yaml");
+    if !recipe_path.exists() {
+        println!("   Creating oxidize.yaml recipe...");
+        let recipe_content = r#"# Oxidize Recipe for external repo
+version: 1
+embedding_model: e5-base-v2
+
+projections:
+  # Semantic projection - observations from same session are similar
+  semantic:
+    layers: [768, 1024, 256]
+    epochs: 10
+    batch_size: 32
+
+  # Temporal projection - files that co-change are related
+  temporal:
+    layers: [768, 1024, 256]
+    epochs: 10
+    batch_size: 32
+
+  # Dependency projection - functions that call each other are related
+  dependency:
+    layers: [768, 1024, 256]
+    epochs: 10
+    batch_size: 32
+"#;
+        fs::write(&recipe_path, recipe_content)?;
+    }
+
+    // Symlink resources directory if it doesn't exist (for embedding models)
+    let repo_resources = repo_path.join("resources");
+    if !repo_resources.exists() && resources_path.exists() {
+        println!("   Linking model resources...");
+        symlink(&resources_path, &repo_resources)
+            .context("Failed to create resources symlink")?;
+    }
+
+    // Run oxidize
+    let result = oxidize::oxidize();
+
+    // Remove symlink after oxidize (clean up)
+    if repo_resources.is_symlink() {
+        let _ = fs::remove_file(&repo_resources);
+    }
+
+    // Restore directory
+    std::env::set_current_dir(original_dir)?;
+
+    result
 }
 
 /// Scrape GitHub issues for a repo

--- a/src/commands/repo/mod.rs
+++ b/src/commands/repo/mod.rs
@@ -41,14 +41,14 @@ pub fn list() -> Result<Vec<RepoEntry>> {
     internal::list_repos()
 }
 
-/// Update a repository (git pull + rescrape)
-pub fn update(name: &str) -> Result<()> {
-    internal::update_repo(name)
+/// Update a repository (git pull + rescrape + optional oxidize)
+pub fn update(name: &str, oxidize: bool) -> Result<()> {
+    internal::update_repo(name, oxidize)
 }
 
 /// Update all repositories
-pub fn update_all() -> Result<()> {
-    internal::update_all_repos()
+pub fn update_all(oxidize: bool) -> Result<()> {
+    internal::update_all_repos(oxidize)
 }
 
 /// Remove a repository
@@ -96,11 +96,11 @@ pub fn execute(command: RepoCommand) -> Result<()> {
             }
             Ok(())
         }
-        RepoCommand::Update { name } => {
+        RepoCommand::Update { name, oxidize } => {
             if let Some(n) = name {
-                update(&n)
+                update(&n, oxidize)
             } else {
-                update_all()
+                update_all(oxidize)
             }
         }
         RepoCommand::Remove { name } => remove(&name),
@@ -119,6 +119,7 @@ pub enum RepoCommand {
     List,
     Update {
         name: Option<String>,
+        oxidize: bool,
     },
     Remove {
         name: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -341,6 +341,10 @@ enum RepoCommands {
         /// Update all repositories
         #[arg(long)]
         all: bool,
+
+        /// Also run oxidize to build semantic indices
+        #[arg(long)]
+        oxidize: bool,
     },
 
     /// Remove a repository
@@ -614,11 +618,11 @@ fn main() -> Result<()> {
                     with_issues,
                 },
                 (Some(RepoCommands::List), _) => RepoCommand::List,
-                (Some(RepoCommands::Update { name, all }), _) => {
+                (Some(RepoCommands::Update { name, all, oxidize }), _) => {
                     if all {
-                        RepoCommand::Update { name: None }
+                        RepoCommand::Update { name: None, oxidize }
                     } else {
-                        RepoCommand::Update { name }
+                        RepoCommand::Update { name, oxidize }
                     }
                 }
                 (Some(RepoCommands::Remove { name }), _) => RepoCommand::Remove { name },

--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,10 @@ enum Commands {
         #[arg(long)]
         repo: Option<String>,
 
+        /// Query all registered repos (current project + reference repos)
+        #[arg(long)]
+        all_repos: bool,
+
         /// Include GitHub issues in search results
         #[arg(long)]
         include_issues: bool,
@@ -539,6 +543,7 @@ fn main() -> Result<()> {
             min_score,
             dimension,
             repo,
+            all_repos,
             include_issues,
         } => {
             let options = commands::scry::ScryOptions {
@@ -547,6 +552,7 @@ fn main() -> Result<()> {
                 dimension,
                 file,
                 repo,
+                all_repos,
                 include_issues,
             };
             commands::scry::execute(query.as_deref(), options)?;
@@ -620,7 +626,10 @@ fn main() -> Result<()> {
                 (Some(RepoCommands::List), _) => RepoCommand::List,
                 (Some(RepoCommands::Update { name, all, oxidize }), _) => {
                     if all {
-                        RepoCommand::Update { name: None, oxidize }
+                        RepoCommand::Update {
+                            name: None,
+                            oxidize,
+                        }
                     } else {
                         RepoCommand::Update { name, oxidize }
                     }


### PR DESCRIPTION
## Summary

- **4b complete:** Reference repo indexing with dependency-only recipe (semantic/temporal require data that doesn't exist)
- **4c complete:** `--all-repos` flag for scry - cross-project search with combined results
- **4e progress:** `/api/scry` endpoint added to serve daemon
- **4d refined:** Deep dive on persona architecture - redefined as learned user model with multiple capture paths

## Changes

### Features
- `patina repo update --oxidize` creates dependency-only recipe for reference repos
- `patina scry --all-repos` searches current project + all reference repos
- `/api/scry` POST endpoint for container/remote queries
- Auto-detect best available dimension (semantic→dependency→temporal→FTS5)

### Documentation
- Persona = learned model of user (not just beliefs)
- Multiple capture paths: reflection, session, distillation, direct
- Storage: `~/.patina/personas/default/` (multi-persona future)
- Build sequence documented for 4d implementation
- Specs aligned with session learnings

## Test plan
- [x] Pre-push checks pass (fmt, clippy, tests)
- [x] `patina repo update --oxidize` tested
- [x] `patina scry --all-repos` tested
- [x] `/api/scry` endpoint tested via curl