### PR TITLE
Phase 2: Agentic RAG with MCP Server

### DIFF
--- a/.patina/config.toml
+++ b/.patina/config.toml
@@ -1,6 +1,5 @@
 [project]
 name = "."
-mode = "owner"
 created = "2025-12-05T16:52:27.714136+00:00"
 
 [dev]
@@ -12,6 +11,11 @@ default = "claude"
 
 [embeddings]
 model = "e5-base-v2"
+
+[search]
+scry_threshold = 0.0
+semantic_threshold = 0.3499999940395355
+belief_threshold = 0.5
 
 [environment]
 os = "macos"

--- a/layer/core/build.md
+++ b/layer/core/build.md
@@ -1,6 +1,6 @@
 # Build Recipe
 
-**Current Phase:** Phase 1 - Launcher & Adapters
+**Current Phase:** Phase 2 Complete - Ready for Lab & Production Testing
 
 ---
 
@@ -206,24 +206,28 @@ struct Cli {
 
 ### Phase 2 Tasks
 
-#### 2a: Oracle Abstraction
-- [ ] Create `Oracle` trait in `src/retrieval/oracle.rs` (strategy pattern, not adapter)
-- [ ] Wrap existing scry functions as oracle implementations
-- [ ] Add parallel query execution with rayon
+#### 2a: Oracle Abstraction ✓
+- [x] Create `Oracle` trait in `src/retrieval/oracle.rs` (strategy pattern, not adapter)
+- [x] Wrap existing scry functions as oracle implementations
+- [x] Add parallel query execution with rayon
 
-#### 2b: Hybrid Retrieval + RRF
-- [ ] Run semantic + BM25 in parallel for every query
-- [ ] Implement RRF fusion (k=60) in `src/retrieval/fusion.rs`
-- [ ] Score normalization across oracles
+#### 2b: Hybrid Retrieval + RRF ✓
+- [x] Run semantic + BM25 in parallel for every query
+- [x] Implement RRF fusion (k=60) in `src/retrieval/fusion.rs`
+- [x] Cross-oracle deduplication for proper RRF boosting
 
-#### 2c: MCP Server
-- [ ] Add `--mcp` flag to `patina serve`
-- [ ] JSON-RPC over stdio transport
-- [ ] Tool registration: `patina_query`, `patina_context`
+#### 2c: MCP Server ✓
+- [x] Add `--mcp` flag to `patina serve`
+- [x] JSON-RPC over stdio transport (hand-rolled, no external SDK)
+- [x] JSON-RPC 2.0 version validation
+- [x] Tool: `patina_query` with hybrid retrieval
+- [x] Rich output format (file path, event type, timestamp)
+- [x] `patina adapter mcp claude` one-command setup
+- [ ] Tool: `patina_context` (project rules/patterns)
 - [ ] Session tools: `patina_session_start/end/note`
 
 #### 2d: Integration Testing
-- [ ] Test with Claude Code MCP config
+- [ ] Test with Claude Code MCP config (immediate next step)
 - [ ] Test with Gemini CLI (when MCP supported)
 - [ ] Latency benchmarks (<500ms target)
 
@@ -231,11 +235,61 @@ struct Cli {
 
 | Criteria | Status |
 |----------|--------|
-| `patina serve --mcp` starts MCP server | [ ] |
-| Claude Code can call `patina_query` tool | [ ] |
-| Returns fused results (semantic + lexical + persona) | [ ] |
-| Latency < 500ms for typical query | [ ] |
-| Session tools work via MCP | [ ] |
+| `patina serve --mcp` starts MCP server | [x] |
+| `patina adapter mcp claude` configures Claude Code | [x] |
+| Claude Code can call `patina_query` tool | [ ] needs live test |
+| Returns fused results (semantic + lexical + persona) | [x] |
+| Output includes metadata (path, event_type, timestamp) | [x] |
+| Latency < 500ms for typical query | [ ] needs benchmark |
+| Session tools work via MCP | [ ] not yet implemented |
+
+---
+
+## Phase 2.5: Lab Readiness
+
+**Goal:** Enable experimentation (new models, fusion strategies) while keeping Patina running in production.
+
+**Philosophy:** Patina is not an academic exercise. It runs daily on hackathons, bounties, and repo contributions while we experiment with its internals.
+
+### Current State Assessment
+
+| Component | Production | Lab Ready | Blocker |
+|-----------|------------|-----------|---------|
+| Scrape pipeline | ✅ | ⚠️ | Schema hardcoded |
+| Embeddings (E5) | ✅ | ❌ | Model locked in code |
+| Retrieval/Oracles | ✅ | ✅ | - |
+| Fusion (RRF) | ✅ | ⚠️ | k=60 hardcoded |
+| MCP server | ✅ | ✅ | - |
+| Persona | ✅ | ⚠️ | Storage format locked |
+| Frontends | ✅ | ✅ | Adapter pattern works |
+
+### Phase 2.5 Tasks
+
+#### 2.5a: Retrieval Configuration
+- [ ] Add `[retrieval]` section to config.toml
+- [ ] Make RRF k value configurable (default 60)
+- [ ] Make fetch_multiplier configurable (default 2x)
+- [ ] Config validation on load
+
+#### 2.5b: Benchmark Infrastructure
+- [ ] `patina bench retrieval` command skeleton
+- [ ] Query set format (JSON with ground truth)
+- [ ] Metrics: MRR, Recall@K, latency p50/p95
+- [ ] Baseline measurement before changes
+
+#### 2.5c: Model Flexibility
+- [ ] Document model addition process
+- [ ] Test with second embedding model (bge-small or nomic)
+- [ ] Verify vector space compatibility
+
+### Validation
+
+| Criteria | Status |
+|----------|--------|
+| Can change RRF k via config | [ ] |
+| `patina bench` produces metrics | [ ] |
+| Second embedding model works | [ ] |
+| No regression in production use | [ ] |
 
 ---
 

--- a/layer/core/build.md
+++ b/layer/core/build.md
@@ -49,9 +49,10 @@ patina --frontend gemini  # Explicit frontend (long flag)
 - [x] Create `resources/gemini/` templates (parity with claude)
 - [x] Create `src/adapters/templates.rs` extraction module
 - [x] Extract templates to `~/.patina/adapters/{frontend}/templates/` on first run
-- [ ] Refactor claude adapter to copy from central templates
-- [ ] Implement gemini adapter with full template support
-- [ ] Update init to use `templates::copy_to_project()`
+- [x] Fix template structure: install to `.{frontend}/` subdirectory for copy_to_project()
+- [x] Implement gemini adapter with full template support (uses templates::copy_to_project)
+- [x] `patina adapter add` creates adapter files from templates
+- [-] Refactor claude adapter - kept as-is (embedded approach works, has version management)
 
 ### 1b: First-Run Setup ✓
 - [x] Detect first run → create `~/.patina/`
@@ -86,8 +87,8 @@ struct Cli {
   - [x] Single y/N question to initialize
   - [x] Auto-init on confirmation
 
-**Remaining:**
-- [ ] Ensure adapter templates exist via `templates::copy_to_project()`
+**Completed** (session 20251211-103012):
+- [x] Ensure adapter templates exist via `templates::copy_to_project()` (in adapter add)
 
 ### 1d: Patina Context Layer
 - [ ] Create `.patina/context.md` schema (patina's project knowledge, LLM-agnostic)
@@ -154,10 +155,10 @@ struct Cli {
 |----------|--------|
 | Gemini templates exist with full parity to Claude | [x] |
 | First-run extracts templates to `~/.patina/adapters/` | [x] |
-| `patina init` copies adapter templates from central location | [ ] |
+| `patina adapter add` copies templates from central location | [x] |
 | `patina` (no args) opens default frontend | [x] |
 | `patina -f claude` opens Claude Code (if allowed) | [x] |
-| `patina -f gemini` opens Gemini CLI (if allowed) | [ ] |
+| `patina -f gemini` opens Gemini CLI (if allowed) | [x] |
 | "Are you lost?" prompt for non-patina projects | [x] |
 | Auto-init on confirmation | [x] |
 | Auto-stash on dirty working tree (with restore hint) | [x] |

--- a/layer/surface/build/spec-agentic-rag.md
+++ b/layer/surface/build/spec-agentic-rag.md
@@ -1,0 +1,646 @@
+# Spec: Agentic RAG System
+
+**Status:** Active Development
+**Phase:** 2 (Agentic RAG)
+**Session:** 20251211-201645
+**Created:** 2025-12-12
+
+---
+
+## Executive Summary
+
+Transform Patina from a passive tool provider into an intelligent retrieval layer. The system uses parallel multi-oracle retrieval with Reciprocal Rank Fusion (RRF) - no local LLM required for routing or synthesis.
+
+**Key Insight:** Research shows parallel retrieval + RRF fusion + frontier LLM synthesis consistently outperforms small-model routing. The complexity of local LLM serving buys nothing.
+
+---
+
+## Design Rationale
+
+### Why NOT Local LLM Routing
+
+The original concept (`layer/surface/concept-orchestration-agent.md`) proposed a small local LLM (Qwen3-0.6B) for:
+- Intent classification (search/explain/suggest)
+- Oracle routing decisions
+- Result synthesis
+
+**Problems identified:**
+
+| Assumption | Reality |
+|------------|---------|
+| Small LLM can route well | Microsoft research: embedding/keyword routers often outperform |
+| Small LLM can synthesize | 0.6B models produce incoherent merges |
+| Intent classification needs ML | Regex patterns work for {search, explain, suggest} |
+| Local inference is free | Model loading ~2GB RAM, tokenizer complexity |
+
+### Why Parallel Retrieval + RRF
+
+State-of-the-art agentic RAG (2024-2025) converges on:
+
+1. **Query → All relevant oracles in parallel**
+2. **RRF fusion** to combine ranked lists
+3. **Frontier LLM synthesizes** (it's better at this)
+
+**Benefits:**
+- No routing decision (eliminates weak link)
+- Parallel execution fast on M-series (unified memory)
+- Simple, deterministic, testable
+- Let each component do what it's best at
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    patina serve --mcp                           │
+│                                                                 │
+│  ┌──────────────────────────────────────────────────────────┐  │
+│  │  MCP Server (JSON-RPC over stdio)                         │  │
+│  │  - Tool registration                                      │  │
+│  │  - Request dispatch                                       │  │
+│  └──────────────────────────────────────────────────────────┘  │
+│                              │                                  │
+│                              ▼                                  │
+│  ┌──────────────────────────────────────────────────────────┐  │
+│  │  Query Processor                                          │  │
+│  │  - Parallel oracle dispatch (rayon)                       │  │
+│  │  - RRF fusion (k=60)                                      │  │
+│  │  - Result formatting                                      │  │
+│  └──────────────────────────────────────────────────────────┘  │
+│                              │                                  │
+│       ┌──────────────────────┼──────────────────────┐          │
+│       ▼                      ▼                      ▼          │
+│  ┌─────────────┐  ┌─────────────────┐  ┌─────────────────┐     │
+│  │ Semantic    │  │ Lexical         │  │ Persona         │     │
+│  │ Oracle      │  │ Oracle          │  │ Oracle          │     │
+│  │             │  │                 │  │                 │     │
+│  │ E5 embed    │  │ BM25/FTS5       │  │ Persona DB      │     │
+│  │ USearch     │  │ SQLite          │  │ Vector search   │     │
+│  └─────────────┘  └─────────────────┘  └─────────────────┘     │
+│       │                      │                      │          │
+│       │              (optional)                     │          │
+│       ▼                      ▼                      ▼          │
+│  ┌─────────────┐  ┌─────────────────┐  ┌─────────────────┐     │
+│  │ Temporal    │  │ Dependency      │  │ GitHub          │     │
+│  │ Oracle      │  │ Oracle          │  │ Oracle          │     │
+│  │             │  │                 │  │                 │     │
+│  │ co_changes  │  │ call_graph      │  │ Issues/PRs      │     │
+│  └─────────────┘  └─────────────────┘  └─────────────────┘     │
+│                              │                                  │
+│                              ▼                                  │
+│  ┌──────────────────────────────────────────────────────────┐  │
+│  │  RRF Fusion                                               │  │
+│  │  score(doc) = Σ 1/(k + rank_i) for each oracle i          │  │
+│  └──────────────────────────────────────────────────────────┘  │
+│                              │                                  │
+│                              ▼                                  │
+│                    Top-K Results with Provenance                │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Alignment with Core Principles
+
+### dependable-rust.md - Black-Box Modules
+
+| Module | "Do X" Statement | Public Interface |
+|--------|------------------|------------------|
+| `retrieval/` | "Retrieve relevant knowledge" | `Oracle`, `QueryEngine`, `query()` |
+| `mcp/` | "Serve MCP protocol over stdio" | `run_mcp_server()` |
+
+Internal details hidden:
+- `fusion.rs` - only QueryEngine uses it
+- `oracles/*` - constructed internally by QueryEngine
+- `protocol.rs` - only server.rs uses it
+
+### unix-philosophy.md - Composition
+
+```
+scry (existing)
+    ↓ wraps
+SemanticOracle
+    ↓ called by
+QueryEngine
+    ↓ uses
+fusion::rrf_fuse()
+    ↓ returns to
+MCP tool handler
+    ↓ formats for
+JSON-RPC response
+```
+
+Each component transforms input → output. Composition, not monolith.
+
+### adapter-pattern.md - Strategy, Not Adapter
+
+**Important:** Oracle is a **strategy pattern**, not an adapter.
+
+- Adapters are for external systems (LLMs, APIs, databases)
+- Oracles are internal retrieval mechanisms wrapping our own code
+
+We use the trait for:
+- **Testability:** Mock oracles for unit tests
+- **Extensibility:** Add temporal/dependency oracles later
+- **Uniform interface:** QueryEngine doesn't know oracle details
+
+This is intentional deviation from adapter-pattern (which targets external systems).
+
+---
+
+## Core Components
+
+### Oracle Trait
+
+```rust
+// src/retrieval/oracle.rs
+
+use anyhow::Result;
+
+/// Result from a single oracle query
+#[derive(Debug, Clone)]
+pub struct OracleResult {
+    /// Unique document identifier (for deduplication)
+    pub doc_id: String,
+    /// Content snippet or summary
+    pub content: String,
+    /// Oracle-specific relevance score (0.0-1.0)
+    pub score: f32,
+    /// Source oracle name
+    pub source: &'static str,
+    /// Additional metadata (file path, timestamp, etc.)
+    pub metadata: OracleMetadata,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct OracleMetadata {
+    pub file_path: Option<String>,
+    pub line_number: Option<u32>,
+    pub timestamp: Option<String>,
+    pub event_type: Option<String>,
+}
+
+/// Oracle interface - each retrieval dimension implements this
+pub trait Oracle: Send + Sync {
+    /// Oracle name for provenance tracking
+    fn name(&self) -> &'static str;
+
+    /// Query the oracle, returning ranked results
+    fn query(&self, query: &str, limit: usize) -> Result<Vec<OracleResult>>;
+
+    /// Whether this oracle is available (index exists, etc.)
+    fn is_available(&self) -> bool;
+}
+```
+
+### Oracle Implementations
+
+```rust
+// Wrap existing scry functions
+
+pub struct SemanticOracle {
+    db_path: PathBuf,
+    index_path: PathBuf,
+}
+
+impl Oracle for SemanticOracle {
+    fn name(&self) -> &'static str { "semantic" }
+
+    fn query(&self, query: &str, limit: usize) -> Result<Vec<OracleResult>> {
+        // Reuse scry::scry_text() internally
+        let options = ScryOptions {
+            limit,
+            dimension: Some("semantic".to_string()),
+            ..Default::default()
+        };
+        let results = scry::scry_text(query, &options)?;
+        Ok(results.into_iter().map(Into::into).collect())
+    }
+
+    fn is_available(&self) -> bool {
+        self.index_path.join("semantic.usearch").exists()
+    }
+}
+
+pub struct LexicalOracle { /* BM25/FTS5 */ }
+pub struct PersonaOracle { /* Persona vector search */ }
+pub struct TemporalOracle { /* co_changes */ }
+pub struct DependencyOracle { /* call_graph */ }
+```
+
+### Parallel Query Execution
+
+```rust
+// src/retrieval/query.rs
+
+use rayon::prelude::*;
+
+pub struct QueryEngine {
+    oracles: Vec<Box<dyn Oracle>>,
+}
+
+impl QueryEngine {
+    pub fn query(&self, query: &str, limit: usize) -> Vec<FusedResult> {
+        // Query all available oracles in parallel
+        let oracle_results: Vec<Vec<OracleResult>> = self.oracles
+            .par_iter()
+            .filter(|o| o.is_available())
+            .map(|oracle| {
+                oracle.query(query, limit * 2)  // Over-fetch for fusion
+                    .unwrap_or_default()
+            })
+            .collect();
+
+        // Fuse results with RRF
+        fusion::rrf_fuse(oracle_results, 60, limit)
+    }
+}
+```
+
+### RRF Fusion
+
+```rust
+// src/retrieval/fusion.rs
+
+use std::collections::HashMap;
+
+/// Fused result with combined score
+#[derive(Debug)]
+pub struct FusedResult {
+    pub doc_id: String,
+    pub content: String,
+    pub fused_score: f32,
+    pub sources: Vec<&'static str>,  // Which oracles contributed
+    pub metadata: OracleMetadata,
+}
+
+/// Reciprocal Rank Fusion
+///
+/// k=60 is standard (from original RRF paper by Cormack et al.)
+/// Higher k reduces impact of top ranks, lower k emphasizes them.
+pub fn rrf_fuse(
+    ranked_lists: Vec<Vec<OracleResult>>,
+    k: usize,
+    limit: usize,
+) -> Vec<FusedResult> {
+    let mut scores: HashMap<String, f32> = HashMap::new();
+    let mut docs: HashMap<String, OracleResult> = HashMap::new();
+    let mut sources: HashMap<String, Vec<&'static str>> = HashMap::new();
+
+    for list in ranked_lists {
+        for (rank, result) in list.iter().enumerate() {
+            // RRF score: 1 / (k + rank + 1)
+            // rank is 0-indexed, so rank 0 -> 1/(k+1)
+            let rrf_score = 1.0 / (k + rank + 1) as f32;
+
+            *scores.entry(result.doc_id.clone()).or_default() += rrf_score;
+
+            sources.entry(result.doc_id.clone())
+                .or_default()
+                .push(result.source);
+
+            docs.entry(result.doc_id.clone())
+                .or_insert_with(|| result.clone());
+        }
+    }
+
+    // Sort by fused score descending
+    let mut fused: Vec<_> = scores.into_iter()
+        .map(|(doc_id, fused_score)| {
+            let doc = docs.remove(&doc_id).unwrap();
+            let doc_sources = sources.remove(&doc_id).unwrap_or_default();
+            FusedResult {
+                doc_id,
+                content: doc.content,
+                fused_score,
+                sources: doc_sources,
+                metadata: doc.metadata,
+            }
+        })
+        .collect();
+
+    fused.sort_by(|a, b| b.fused_score.partial_cmp(&a.fused_score).unwrap());
+    fused.truncate(limit);
+    fused
+}
+```
+
+---
+
+## MCP Integration
+
+### Design: Blocking stdio, No External SDK
+
+MCP is JSON-RPC 2.0 over stdio. We implement it directly:
+
+- **unix-philosophy**: Simple line-based protocol, no framework magic
+- **dependable-rust**: Minimal dependencies (serde_json only), stable interface
+- **Blocking I/O**: Consistent with existing serve command (rouille)
+
+~150 lines of explicit code. All behavior visible and debuggable.
+
+### Protocol Types
+
+```rust
+// src/mcp/protocol.rs
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+pub struct JsonRpcRequest {
+    pub jsonrpc: String,  // "2.0"
+    pub id: Option<serde_json::Value>,
+    pub method: String,
+    pub params: Option<serde_json::Value>,
+}
+
+#[derive(Serialize)]
+pub struct JsonRpcResponse {
+    pub jsonrpc: String,
+    pub id: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<JsonRpcError>,
+}
+
+#[derive(Serialize)]
+pub struct JsonRpcError {
+    pub code: i32,
+    pub message: String,
+}
+
+#[derive(Serialize)]
+pub struct Tool {
+    pub name: String,
+    pub description: String,
+    #[serde(rename = "inputSchema")]
+    pub input_schema: serde_json::Value,
+}
+```
+
+### Tool Definitions
+
+```rust
+// src/mcp/tools.rs
+
+pub fn get_tools() -> Vec<Tool> {
+    vec![
+        Tool {
+            name: "patina_query".to_string(),
+            description: "Search your codebase knowledge using hybrid retrieval. \
+                Returns relevant code, patterns, decisions, and session history. \
+                Results are fused from semantic search, lexical search, and persona.".to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "query": {
+                        "type": "string",
+                        "description": "Natural language question or code search query"
+                    },
+                    "limit": {
+                        "type": "integer",
+                        "description": "Maximum results to return (default: 10)",
+                        "default": 10
+                    }
+                },
+                "required": ["query"]
+            }),
+        },
+        Tool {
+            name: "patina_context".to_string(),
+            description: "Get project context and rules. Returns architecture info, \
+                patterns, and constraints from the knowledge base.".to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "topic": {
+                        "type": "string",
+                        "description": "Optional topic to focus on (e.g., 'error handling', 'testing')"
+                    }
+                }
+            }),
+        },
+        Tool {
+            name: "patina_session_start".to_string(),
+            description: "Start a tracked development session.".to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "Session name/goal"
+                    }
+                },
+                "required": ["name"]
+            }),
+        },
+        Tool {
+            name: "patina_session_note".to_string(),
+            description: "Capture an insight during the current session.".to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "note": {
+                        "type": "string",
+                        "description": "The insight to capture"
+                    }
+                },
+                "required": ["note"]
+            }),
+        },
+        Tool {
+            name: "patina_session_end".to_string(),
+            description: "End the current session and archive learnings.".to_string(),
+            input_schema: serde_json::json!({
+                "type": "object",
+                "properties": {
+                    "summary": {
+                        "type": "string",
+                        "description": "Brief summary of what was accomplished"
+                    }
+                }
+            }),
+        },
+    ]
+}
+```
+
+### MCP Server (stdio)
+
+```rust
+// src/mcp/server.rs
+
+use std::io::{BufRead, Write, BufReader};
+use anyhow::Result;
+
+pub fn run_mcp_server() -> Result<()> {
+    let stdin = std::io::stdin();
+    let mut stdout = std::io::stdout();
+    let reader = BufReader::new(stdin.lock());
+
+    // Initialize query engine
+    let engine = QueryEngine::new()?;
+
+    for line in reader.lines() {
+        let line = line?;
+        if line.is_empty() { continue; }
+
+        let request: JsonRpcRequest = match serde_json::from_str(&line) {
+            Ok(r) => r,
+            Err(e) => {
+                let resp = error_response(None, -32700, &format!("Parse error: {}", e));
+                writeln!(stdout, "{}", serde_json::to_string(&resp)?)?;
+                stdout.flush()?;
+                continue;
+            }
+        };
+
+        let response = handle_request(&request, &engine);
+        writeln!(stdout, "{}", serde_json::to_string(&response)?)?;
+        stdout.flush()?;
+    }
+
+    Ok(())
+}
+
+fn handle_request(request: &JsonRpcRequest, engine: &QueryEngine) -> JsonRpcResponse {
+    match request.method.as_str() {
+        "initialize" => handle_initialize(request),
+        "tools/list" => handle_list_tools(request),
+        "tools/call" => handle_tool_call(request, engine),
+        _ => error_response(request.id.clone(), -32601, "Method not found"),
+    }
+}
+```
+
+### Claude Code Configuration
+
+```json
+// ~/Library/Application Support/Claude/claude_desktop_config.json
+{
+  "mcpServers": {
+    "patina": {
+      "command": "/Users/you/.cargo/bin/patina",
+      "args": ["serve", "--mcp"]
+    }
+  }
+}
+```
+
+---
+
+## File Structure
+
+**Note:** Module named `retrieval/` not `agent/` - describes what it does, not what it pretends to be (we removed the "agent" concept).
+
+```
+src/
+├── retrieval/
+│   ├── mod.rs              # Public: Oracle trait, QueryEngine, query()
+│   ├── oracle.rs           # Oracle trait + OracleResult (strategy pattern)
+│   ├── oracles/            # Internal: concrete implementations
+│   │   ├── mod.rs          # pub(crate) - not exposed externally
+│   │   ├── semantic.rs     # E5 + USearch
+│   │   ├── lexical.rs      # BM25/FTS5
+│   │   ├── persona.rs      # Persona vector search
+│   │   ├── temporal.rs     # co_changes (future)
+│   │   └── dependency.rs   # call_graph (future)
+│   ├── fusion.rs           # Internal: RRF implementation
+│   └── query.rs            # QueryEngine (parallel dispatch)
+│
+├── mcp/
+│   ├── mod.rs              # Public: run_mcp_server()
+│   ├── protocol.rs         # Internal: JSON-RPC types
+│   ├── server.rs           # Internal: stdio transport
+│   └── tools.rs            # Internal: tool definitions + handlers
+│
+└── commands/
+    └── serve/
+        ├── mod.rs          # Add --mcp flag
+        └── internal.rs     # HTTP server (unchanged)
+```
+
+---
+
+## Implementation Order
+
+### Weekend Sprint
+
+**Saturday Morning: Oracle Abstraction**
+1. Create `src/retrieval/mod.rs` with exports
+2. Create `src/retrieval/oracle.rs` with trait + types
+3. Wrap `scry::scry_text()` as SemanticOracle
+4. Wrap `scry::scry_lexical()` as LexicalOracle
+5. Wrap `persona::query()` as PersonaOracle
+
+**Saturday Afternoon: Parallel Query + RRF**
+1. Create `src/retrieval/fusion.rs` with RRF
+2. Create `src/retrieval/query.rs` with QueryEngine
+3. Add rayon dependency
+4. Unit tests for RRF (deterministic, easy)
+
+**Sunday Morning: MCP Protocol**
+1. Create `src/mcp/protocol.rs` with types
+2. Create `src/mcp/tools.rs` with tool definitions
+3. Create `src/mcp/server.rs` with stdio loop
+
+**Sunday Afternoon: Integration**
+1. Add `--mcp` flag to serve command
+2. Wire QueryEngine to tool handlers
+3. Test with Claude Code
+4. Latency profiling
+
+---
+
+## Latency Budget
+
+Target: < 500ms end-to-end
+
+| Stage | Budget | Notes |
+|-------|--------|-------|
+| MCP parse | 1ms | JSON parsing |
+| Embedding | 50ms | E5 query embedding |
+| Semantic search | 30ms | USearch ~10ms, SQLite enrichment ~20ms |
+| Lexical search | 20ms | FTS5 is fast |
+| Persona search | 30ms | Similar to semantic |
+| RRF fusion | 5ms | In-memory HashMap |
+| Response format | 5ms | JSON serialization |
+| **Total** | ~140ms | Well under budget |
+
+Parallel execution means semantic/lexical/persona run concurrently, so actual time is ~max(50+30, 20, 30) + overhead = ~100ms.
+
+---
+
+## What We're NOT Building
+
+| Feature | Why Skip |
+|---------|----------|
+| Local LLM routing | Research shows it underperforms |
+| Intent classification | Frontier LLM handles this |
+| Result synthesis | Frontier LLM's job |
+| Query expansion | Start simple, add if needed |
+| Cross-encoder reranker | Phase 4 optimization |
+
+---
+
+## Success Criteria
+
+| Criteria | Target |
+|----------|--------|
+| MCP server starts | `patina serve --mcp` works |
+| Tool discovery | Claude sees patina_query |
+| Hybrid retrieval | Fuses semantic + lexical |
+| Latency | < 500ms |
+| Persona included | Session knowledge in results |
+
+---
+
+## References
+
+- **RRF Paper:** Cormack, Clarke, Buettcher (2009) - "Reciprocal Rank Fusion outperforms Condorcet and individual rank learning methods"
+- **Hybrid Search:** MTEB/BEIR benchmarks show semantic + BM25 consistently +5-10%
+- **MCP Spec:** https://modelcontextprotocol.io/
+- **Prior Concept:** `layer/surface/concept-orchestration-agent.md` (superseded)
+- **Session:** 20251211-201645 (design discussion)

--- a/layer/surface/concept-orchestration-agent.md
+++ b/layer/surface/concept-orchestration-agent.md
@@ -1,0 +1,418 @@
+# Concept: On-Device Orchestration Agent
+
+**Status:** SUPERSEDED by [spec-agentic-rag.md](build/spec-agentic-rag.md)
+**Created:** 2025-12-11
+**Session:** 20251211-140201
+**Superseded:** 2025-12-12 (Session 20251211-201645)
+
+> **Note:** This concept proposed local LLM routing. After research review,
+> we determined parallel retrieval + RRF fusion is simpler and more effective.
+> See the new spec for the implemented approach.
+
+---
+
+## Executive Summary
+
+An on-device orchestration agent that runs on Apple Silicon, receives queries from LLM frontends (Claude Code, Gemini CLI) via MCP, routes to appropriate oracles, and synthesizes contextual answers. The agent uses a small local LLM (Qwen3-0.6B or similar) for routing/synthesis while keeping all sensitive context on-device.
+
+**Key Insight:** Patina becomes the intelligent middle layer, not just a tool provider.
+
+---
+
+## Pain Points This Solves
+
+| Pain Point | Evidence | How Agent Solves |
+|------------|----------|------------------|
+| Stuck at semantic only | Session 20251125-065729: "1/6 dimensions implemented" | Agent coordinates multiple oracles |
+| LLM orchestration burden | Session 20251026-072236: "Claude IS the intelligent agent" | Agent handles routing/combining |
+| Context window limits | Can't send all 277 sessions to LLM | Agent retrieves TOP-K relevant |
+| No smart retrieval | Session 20251029-084321: "Undefined how LLM queries beliefs" | Agent assembles context |
+| Privacy concerns | Sessions contain sensitive project context | Sessions never leave device |
+| Cost | Every routing decision = frontier tokens | Local decisions = 0 cloud tokens |
+| Latency | Cloud roundtrip for simple decisions | Local inference ~60ms |
+| Cross-project coordination | Mothership needs intelligence | Agent queries across nodes |
+
+---
+
+## Architecture
+
+### The Two Models (Context)
+
+**Model A: "Claude IS the Agent" (Current)**
+```
+Claude Code (Orchestrator)
+    ↓ calls
+Patina CLI / MCP Tools (Oracles)
+    ↓ queries
+Knowledge Graph + SQLite + Prolog
+```
+- LLM frontend does all orchestration
+- Patina provides tools/oracles
+- Simple, works now
+
+**Model B: "On-Device Orchestration Agent" (Proposed)**
+```
+Claude Code / Gemini CLI
+    ↓ calls via MCP
+Patina Agent (Apple Silicon, ONNX Runtime)
+    ↓ orchestrates
+┌────────────┬────────────┬────────────┐
+│ Semantic   │ Temporal   │ Session    │
+│ Oracle     │ Oracle     │ Oracle     │
+└────────────┴────────────┴────────────┘
+    ↓ queries
+Knowledge Graph + SQLite + Prolog
+```
+- Agent runs ON-DEVICE (Mac, Apple Silicon)
+- LLM frontends call INTO the agent via MCP
+- Agent decides WHAT to query and HOW to combine
+- Small, fast model does routing/orchestration
+- Frontier LLM stays focused on reasoning with user
+
+---
+
+### Full Architecture Diagram
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                    LLM Frontends                                │
+│              (Claude Code, Gemini CLI)                          │
+└─────────────────────────┬───────────────────────────────────────┘
+                          │ MCP (JSON-RPC over stdio)
+                          ▼
+┌─────────────────────────────────────────────────────────────────┐
+│              PATINA MCP SERVER (Rust)                           │
+│                                                                 │
+│  ┌──────────────────────────────────────────────────────────┐  │
+│  │  Orchestration Agent                                      │  │
+│  │  ┌────────────────────────────────────────────────────┐  │  │
+│  │  │  Local LLM (ort crate, ONNX Runtime)               │  │  │
+│  │  │  - Qwen3-0.6B or similar (ONNX format)             │  │  │
+│  │  │  - Query routing, intent classification            │  │  │
+│  │  │  - Result synthesis                                │  │  │
+│  │  └────────────────────────────────────────────────────┘  │  │
+│  └──────────────────────────────────────────────────────────┘  │
+│                              │                                  │
+│              ┌───────────────┼───────────────┐                  │
+│              ▼               ▼               ▼                  │
+│  ┌─────────────────┐ ┌─────────────────┐ ┌─────────────────┐   │
+│  │ Semantic Oracle │ │ Temporal Oracle │ │ Session Oracle  │   │
+│  │ (E5 + USearch)  │ │ (co_changes)    │ │ (obs + beliefs) │   │
+│  └─────────────────┘ └─────────────────┘ └─────────────────┘   │
+│                                                                 │
+│  All Rust. No Python. ONNX Runtime for all ML.                 │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## How Frontends Discover the Agent
+
+MCP has built-in tool discovery. When a frontend connects, it asks "what tools do you have?" and the server responds with schemas.
+
+### Tool Registration
+
+```rust
+ToolDefinition {
+    name: "patina_query",
+    description: "Query your codebase knowledge. Ask questions about \
+        code, patterns, decisions, or how things work. The agent \
+        routes to appropriate oracles and synthesizes answers.",
+    input_schema: {
+        "type": "object",
+        "properties": {
+            "query": {
+                "type": "string",
+                "description": "Natural language question about the codebase"
+            },
+            "intent": {
+                "type": "string",
+                "enum": ["search", "explain", "suggest"],
+                "description": "Optional hint about query intent"
+            }
+        },
+        "required": ["query"]
+    }
+}
+```
+
+### Frontend Configuration
+
+**Claude Code** (`settings.json`):
+```json
+{
+  "mcpServers": {
+    "patina": {
+      "command": "patina",
+      "args": ["serve", "--mcp"]
+    }
+  }
+}
+```
+
+### Discovery Flow
+
+```
+1. Frontend connects to Patina MCP Server
+2. Frontend: "list_tools"
+3. Patina returns: [patina_query, patina_context, patina_session_*, ...]
+4. LLM reads descriptions, knows when to call each tool
+5. User: "How does error handling work here?"
+6. LLM reasons: "codebase question → patina_query"
+7. LLM calls: patina_query({ query: "error handling" })
+8. Agent routes, synthesizes, returns structured answer
+9. LLM presents answer to user
+```
+
+---
+
+## Integration with Scry & Scrape
+
+### Scrape: Feeds the Oracles
+
+```
+patina scrape code     → Semantic Oracle (code.db, USearch, embeddings)
+                       → Temporal Oracle (co_changes table)
+
+patina scrape session  → Session Oracle (observations.db, beliefs)
+
+patina scrape github   → GitHub Oracle (issues, PRs, bounties)
+```
+
+### Scry: Direct Oracle Access (CLI)
+
+```bash
+# Simple semantic search - NO agent needed
+$ patina scry "error handling"
+
+Results:
+1. src/error.rs (0.92)
+2. layer/core/patterns/error-context.md (0.87)
+```
+
+### Agent: Orchestrated Multi-Oracle (MCP)
+
+```
+Claude: patina_query("how is error handling done?")
+
+Agent:
+  → Classifies: "explain" intent
+  → Routes to: semantic + session + temporal
+  → Semantic: src/error.rs, patterns/error-context.md
+  → Session: 3 sessions discussed error strategy
+  → Temporal: error.rs changes with result.rs
+  → Synthesizes combined answer
+  → Returns with sources and confidence
+```
+
+### Command Interface
+
+```bash
+# INGESTION (unchanged)
+patina scrape code
+patina scrape session
+patina scrape github
+
+# QUERY
+patina scry "query"           # Direct semantic (fast, CLI)
+patina scry "query" --deep    # Agent-mediated (optional)
+
+# SERVE (new)
+patina serve                  # Start MCP server with agent
+patina serve --mcp            # MCP-only mode (stdio)
+patina serve --http :8080     # HTTP API mode
+```
+
+---
+
+## Language Stack
+
+**Constraint:** Rust, TypeScript, Swift. NO PYTHON.
+
+### Why This Matters
+
+MLX (Apple's ML framework) is Python-first. We need Rust-native solutions.
+
+### Solution: ONNX Runtime via `ort` crate
+
+We already use `ort` for E5 embeddings. Same runtime for local LLM.
+
+```rust
+// Current: embeddings
+let embedding_model = ort::Session::from_file("e5-base-v2.onnx")?;
+
+// New: local LLM (same runtime!)
+let agent_model = ort::Session::from_file("qwen3-0.6b.onnx")?;
+```
+
+### Model Options (ONNX-compatible)
+
+| Model | Size | Use Case |
+|-------|------|----------|
+| Qwen3-0.6B | 600MB | Query routing, classification |
+| Phi-3-mini | 2.3GB | Synthesis, ranking |
+| OLMo-1B | 1GB | General orchestration |
+
+### Code Structure
+
+```
+src/
+├── agent/
+│   ├── mod.rs
+│   ├── model.rs           # ONNX model loading (ort)
+│   ├── router.rs          # Intent classification
+│   ├── synthesizer.rs     # Result combination
+│   └── oracles/
+│       ├── semantic.rs    # USearch + E5
+│       ├── temporal.rs    # co_changes queries
+│       └── session.rs     # observations + beliefs
+│
+├── mcp/
+│   ├── mod.rs
+│   ├── server.rs          # JSON-RPC over stdio
+│   ├── tools.rs           # Tool definitions
+│   └── protocol.rs        # MCP types
+│
+└── commands/
+    ├── serve.rs           # patina serve
+    ├── scry.rs            # patina scry
+    └── scrape/            # patina scrape
+```
+
+### When TS/Swift?
+
+```
+Rust:   CLI, Agent, MCP Server, Oracles (99%)
+TS:     Future web dashboard, MCP testing utilities
+Swift:  macOS menu bar app, Spotlight integration (future)
+```
+
+---
+
+## Privacy Boundary
+
+```
+┌─────────────────────────────────────────┐
+│  DEVICE BOUNDARY                        │
+│                                         │
+│  Sessions (sensitive)                   │
+│  Beliefs (personal)                     │
+│  Project context                        │
+│              ↓                          │
+│  Orchestration Agent                    │
+│  Synthesizes → abstracts →              │
+│  returns ANSWER not raw data            │
+│              ↓                          │
+│       Synthesized Answer                │
+└─────────────────────────────────────────┘
+              ↓
+         To Cloud LLM
+         Only sees: answer, not raw sessions
+```
+
+---
+
+## Cost & Latency Benefits
+
+### Token Savings
+
+| Decision Type | Before (Cloud) | After (Local) |
+|---------------|----------------|---------------|
+| "Which oracle?" | ~500 tokens | 0 |
+| "Rank results" | ~1000 tokens | 0 |
+| "Combine answers" | ~800 tokens | 0 |
+| Complex reasoning | Cloud | Cloud |
+
+**Estimated savings:** 80%+ orchestration tokens stay local
+
+### Latency
+
+```
+Before: Query → Cloud (200ms) → Response → Cloud (200ms) → ...
+After:  Query → Local (20ms) → Oracles (10ms) → Synthesize (30ms)
+
+~60ms local vs 400ms+ cloud roundtrips
+```
+
+---
+
+## Implementation Path
+
+### Phase 2a: Agent Foundation
+- [ ] MCP server skeleton (Rust, stdio transport)
+- [ ] Tool definitions (patina_query, patina_context)
+- [ ] Basic routing (keyword-based, no ML yet)
+- [ ] Integration with existing scry/semantic oracle
+
+### Phase 2b: Local LLM Integration
+- [ ] ONNX model loading via `ort`
+- [ ] Tokenizer integration
+- [ ] Query intent classification
+- [ ] Result synthesis
+
+### Phase 2c: Multi-Oracle Coordination
+- [ ] Temporal oracle (co_changes)
+- [ ] Session oracle (observations + beliefs)
+- [ ] Result fusion and ranking
+- [ ] Confidence scoring (Prolog integration)
+
+### Phase 2d: Mothership Integration
+- [ ] Cross-project queries
+- [ ] Persona-aware responses
+- [ ] Model management (`patina model pull`)
+
+---
+
+## Open Questions
+
+### Architecture
+
+1. **MCP transport:** stdio (simple) vs Unix socket (persistent)?
+2. **Agent model serving:** In-process vs sidecar?
+3. **Scry --deep:** Should CLI invoke agent, or agent-only via serve?
+
+### Models
+
+4. **Which small LLM?** Qwen3-0.6B vs Phi-3-mini vs OLMo-1B
+5. **Model distribution:** Ship with patina? Download on first serve?
+6. **Fine-tuning:** Train on session queries for better routing?
+
+### Integration
+
+7. **Scrape triggers refresh?** Agent needs to know about new data
+8. **Fallback:** What if local model unavailable? Degrade to direct oracle?
+9. **Caching:** Cache agent responses? Invalidation strategy?
+
+---
+
+## Key References
+
+### Sessions
+- 20251204-173633: "LLM-agnostic agentic RAG network" identity
+- 20251120-110914: "LLM as Orchestrator, Patina as Oracle" + OLMo mention
+- 20251116-223532: Mac Studio architecture, containers call Mac
+- 20251026-072236: Three-layer architecture (observations → beliefs → agent)
+- 20251029-084321: "Layer 3: Intelligent Agent" concept
+- 20251125-065729: "Stuck at semantic only" pain point
+
+### Existing Code
+- `src/indexer/` - E5 embeddings via ort
+- `src/commands/scry/` - Semantic search
+- `src/commands/scrape/` - Knowledge ingestion
+- `.patina/db/` - SQLite storage
+
+### Core Principles
+- `layer/core/unix-philosophy.md` - One tool, one job
+- `layer/core/adapter-pattern.md` - Trait-based external integration
+- `layer/core/dependable-rust.md` - Small stable interfaces
+
+---
+
+## Next Steps (Future Session)
+
+1. Review and refine this concept
+2. Decide on MCP transport (stdio vs socket)
+3. Prototype MCP server skeleton
+4. Evaluate small LLM options (benchmark on Mac)
+5. Define tool schemas in detail

--- a/src/adapters/gemini/internal/mod.rs
+++ b/src/adapters/gemini/internal/mod.rs
@@ -1,9 +1,10 @@
-//! Internal implementation for Gemini adapter (stub)
+//! Internal implementation for Gemini adapter
 
 use anyhow::Result;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+use crate::adapters::templates;
 use crate::environment::Environment;
 
 /// Path constants for Gemini adapter
@@ -16,11 +17,11 @@ pub fn init_project(
     project_name: &str,
     environment: &Environment,
 ) -> Result<()> {
-    // Create .gemini directory
-    let gemini_path = project_path.join(ADAPTER_DIR);
-    fs::create_dir_all(&gemini_path)?;
+    // Copy templates from central location (~/.patina/adapters/gemini/templates/)
+    templates::copy_to_project("gemini", project_path)?;
 
-    // Generate initial context
+    // Generate context file in .gemini/
+    let gemini_path = project_path.join(ADAPTER_DIR);
     let content = generate_minimal_context(project_name, environment);
     fs::write(gemini_path.join(CONTEXT_FILE), content)?;
 

--- a/src/adapters/templates.rs
+++ b/src/adapters/templates.rs
@@ -104,12 +104,16 @@ pub fn templates_installed(frontend: &str) -> bool {
 
 fn install_claude_templates(adapters_dir: &Path) -> Result<()> {
     let templates_dir = adapters_dir.join("claude").join("templates");
-    let bin_dir = templates_dir.join("bin");
-    let commands_dir = templates_dir.join("commands");
+    // Create .claude/ structure inside templates/ so copy_to_project works correctly
+    let claude_dir = templates_dir.join(".claude");
+    let bin_dir = claude_dir.join("bin");
+    let commands_dir = claude_dir.join("commands");
+    let context_dir = claude_dir.join("context");
 
     // Create directories
     fs::create_dir_all(&bin_dir)?;
     fs::create_dir_all(&commands_dir)?;
+    fs::create_dir_all(&context_dir)?;
 
     // Write shell scripts
     write_executable(
@@ -170,8 +174,10 @@ fn install_claude_templates(adapters_dir: &Path) -> Result<()> {
 
 fn install_gemini_templates(adapters_dir: &Path) -> Result<()> {
     let templates_dir = adapters_dir.join("gemini").join("templates");
-    let bin_dir = templates_dir.join("bin");
-    let commands_dir = templates_dir.join("commands");
+    // Create .gemini/ structure inside templates/ so copy_to_project works correctly
+    let gemini_dir = templates_dir.join(".gemini");
+    let bin_dir = gemini_dir.join("bin");
+    let commands_dir = gemini_dir.join("commands");
 
     // Create directories
     fs::create_dir_all(&bin_dir)?;
@@ -305,9 +311,12 @@ mod tests {
         let temp = TempDir::new().unwrap();
         install_claude_templates(temp.path()).unwrap();
 
+        // Templates install to .claude/ structure for copy_to_project()
         let templates_dir = temp.path().join("claude/templates");
-        assert!(templates_dir.join("bin/session-start.sh").exists());
-        assert!(templates_dir.join("commands/session-start.md").exists());
+        assert!(templates_dir.join(".claude/bin/session-start.sh").exists());
+        assert!(templates_dir
+            .join(".claude/commands/session-start.md")
+            .exists());
     }
 
     #[test]
@@ -315,9 +324,12 @@ mod tests {
         let temp = TempDir::new().unwrap();
         install_gemini_templates(temp.path()).unwrap();
 
+        // Templates install to .gemini/ structure for copy_to_project()
         let templates_dir = temp.path().join("gemini/templates");
-        assert!(templates_dir.join("bin/session-start.sh").exists());
-        assert!(templates_dir.join("commands/session-start.toml").exists());
+        assert!(templates_dir.join(".gemini/bin/session-start.sh").exists());
+        assert!(templates_dir
+            .join(".gemini/commands/session-start.toml")
+            .exists());
         assert!(templates_dir.join("GEMINI.md").exists());
     }
 }

--- a/src/commands/adapter.rs
+++ b/src/commands/adapter.rs
@@ -187,7 +187,14 @@ fn add(name: &str) -> Result<()> {
     println!("✓ Added '{}' to allowed frontends", name);
     println!("  Allowed: {:?}", config.frontends.allowed);
 
-    // TODO: Copy adapter templates if needed
+    // Create adapter files if they don't exist
+    let adapter_dir = cwd.join(format!(".{}", name));
+    if !adapter_dir.exists() {
+        println!("  Creating .{}/ directory...", name);
+        patina::adapters::templates::copy_to_project(name, &cwd)?;
+        println!("  ✓ Created adapter files");
+    }
+
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,8 @@ use anyhow::Result;
 use clap::{Args, Parser, Subcommand, ValueEnum};
 
 mod commands;
+mod mcp;
+mod retrieval;
 
 // ============================================================================
 // Typed CLI enums (Phase 0d: type safety for string args)
@@ -315,6 +317,10 @@ enum Commands {
         /// Port to bind to
         #[arg(long, default_value = "50051")]
         port: u16,
+
+        /// Run as MCP server (JSON-RPC over stdio) instead of HTTP
+        #[arg(long)]
+        mcp: bool,
     },
 
     /// List available AI frontends
@@ -727,9 +733,13 @@ fn main() -> Result<()> {
         Some(Commands::Version { json, components }) => {
             commands::version::execute(json, components)?;
         }
-        Some(Commands::Serve { host, port }) => {
-            let options = commands::serve::ServeOptions { host, port };
-            commands::serve::execute(options)?;
+        Some(Commands::Serve { host, port, mcp }) => {
+            if mcp {
+                mcp::run_mcp_server()?;
+            } else {
+                let options = commands::serve::ServeOptions { host, port };
+                commands::serve::execute(options)?;
+            }
         }
         Some(Commands::Adapter { command }) => commands::adapter::execute(command)?,
     }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1,0 +1,8 @@
+//! MCP (Model Context Protocol) server
+//!
+//! JSON-RPC 2.0 over stdio. No external SDK - blocking I/O, minimal dependencies.
+
+mod protocol;
+mod server;
+
+pub use server::run_mcp_server;

--- a/src/mcp/protocol.rs
+++ b/src/mcp/protocol.rs
@@ -1,0 +1,52 @@
+//! JSON-RPC 2.0 protocol types for MCP
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize)]
+pub struct Request {
+    pub jsonrpc: String,
+    pub id: Option<serde_json::Value>,
+    pub method: String,
+    #[serde(default)]
+    pub params: serde_json::Value,
+}
+
+#[derive(Serialize)]
+pub struct Response {
+    pub jsonrpc: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<Error>,
+}
+
+#[derive(Serialize)]
+pub struct Error {
+    pub code: i32,
+    pub message: String,
+}
+
+impl Response {
+    pub fn success(id: Option<serde_json::Value>, result: serde_json::Value) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            id,
+            result: Some(result),
+            error: None,
+        }
+    }
+
+    pub fn error(id: Option<serde_json::Value>, code: i32, message: &str) -> Self {
+        Self {
+            jsonrpc: "2.0",
+            id,
+            result: None,
+            error: Some(Error {
+                code,
+                message: message.to_string(),
+            }),
+        }
+    }
+}

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1,0 +1,194 @@
+//! MCP server - stdio transport
+
+use anyhow::Result;
+use std::io::{BufRead, BufReader, Write};
+
+use super::protocol::{Request, Response};
+use crate::retrieval::{FusedResult, QueryEngine};
+
+/// Run MCP server over stdio
+pub fn run_mcp_server() -> Result<()> {
+    let stdin = std::io::stdin();
+    let mut stdout = std::io::stdout();
+    let reader = BufReader::new(stdin.lock());
+
+    // Initialize query engine
+    let engine = QueryEngine::new();
+
+    eprintln!("patina: MCP server ready");
+
+    for line in reader.lines() {
+        let line = line?;
+        if line.is_empty() {
+            continue;
+        }
+
+        let request: Request = match serde_json::from_str(&line) {
+            Ok(r) => r,
+            Err(e) => {
+                let resp = Response::error(None, -32700, &format!("Parse error: {}", e));
+                writeln!(stdout, "{}", serde_json::to_string(&resp)?)?;
+                stdout.flush()?;
+                continue;
+            }
+        };
+
+        // Validate JSON-RPC version
+        if request.jsonrpc != "2.0" {
+            let resp = Response::error(
+                request.id.clone(),
+                -32600,
+                &format!(
+                    "Invalid JSON-RPC version: expected 2.0, got {}",
+                    request.jsonrpc
+                ),
+            );
+            writeln!(stdout, "{}", serde_json::to_string(&resp)?)?;
+            stdout.flush()?;
+            continue;
+        }
+
+        let response = dispatch(&request, &engine);
+        writeln!(stdout, "{}", serde_json::to_string(&response)?)?;
+        stdout.flush()?;
+    }
+
+    Ok(())
+}
+
+fn dispatch(req: &Request, engine: &QueryEngine) -> Response {
+    match req.method.as_str() {
+        "initialize" => handle_initialize(req, engine),
+        "initialized" => Response::success(req.id.clone(), serde_json::json!({})),
+        "tools/list" => handle_list_tools(req),
+        "tools/call" => handle_tool_call(req, engine),
+        _ => Response::error(req.id.clone(), -32601, "Method not found"),
+    }
+}
+
+fn handle_initialize(req: &Request, engine: &QueryEngine) -> Response {
+    Response::success(
+        req.id.clone(),
+        serde_json::json!({
+            "protocolVersion": "2024-11-05",
+            "capabilities": {
+                "tools": {}
+            },
+            "serverInfo": {
+                "name": "patina",
+                "version": env!("CARGO_PKG_VERSION"),
+                "oracles": engine.available_oracles()
+            }
+        }),
+    )
+}
+
+fn handle_list_tools(req: &Request) -> Response {
+    Response::success(
+        req.id.clone(),
+        serde_json::json!({
+            "tools": [
+                {
+                    "name": "patina_query",
+                    "description": "Search codebase knowledge using hybrid retrieval. Returns relevant code, patterns, decisions, and session history fused from semantic search, lexical search, and persona.",
+                    "inputSchema": {
+                        "type": "object",
+                        "properties": {
+                            "query": {
+                                "type": "string",
+                                "description": "Natural language question or code search query"
+                            },
+                            "limit": {
+                                "type": "integer",
+                                "description": "Maximum results to return (default: 10)",
+                                "default": 10
+                            }
+                        },
+                        "required": ["query"]
+                    }
+                }
+            ]
+        }),
+    )
+}
+
+fn handle_tool_call(req: &Request, engine: &QueryEngine) -> Response {
+    let name = req
+        .params
+        .get("name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+    let args = req.params.get("arguments").cloned().unwrap_or_default();
+
+    match name {
+        "patina_query" => {
+            let query = args.get("query").and_then(|v| v.as_str()).unwrap_or("");
+            let limit = args.get("limit").and_then(|v| v.as_u64()).unwrap_or(10) as usize;
+
+            if query.is_empty() {
+                return Response::error(
+                    req.id.clone(),
+                    -32602,
+                    "Missing required parameter: query",
+                );
+            }
+
+            match engine.query(query, limit) {
+                Ok(results) => {
+                    let text = format_results(&results);
+                    Response::success(
+                        req.id.clone(),
+                        serde_json::json!({
+                            "content": [{ "type": "text", "text": text }]
+                        }),
+                    )
+                }
+                Err(e) => Response::error(req.id.clone(), -32603, &e.to_string()),
+            }
+        }
+        _ => Response::error(req.id.clone(), -32602, &format!("Unknown tool: {}", name)),
+    }
+}
+
+fn format_results(results: &[FusedResult]) -> String {
+    if results.is_empty() {
+        return "No results found.".to_string();
+    }
+
+    let mut output = String::new();
+    for (i, result) in results.iter().enumerate() {
+        // Header: rank, sources, score
+        output.push_str(&format!(
+            "{}. [{}] (score: {:.3})",
+            i + 1,
+            result.sources.join("+"),
+            result.fused_score
+        ));
+
+        // Location: file path or doc_id for non-file results
+        if let Some(ref path) = result.metadata.file_path {
+            output.push_str(&format!(" {}", path));
+        } else {
+            // For persona/session results without file path, show doc_id
+            output.push_str(&format!(" {}", result.doc_id));
+        }
+
+        // Event type (e.g., "code_chunk", "session", "observation")
+        if let Some(ref event_type) = result.metadata.event_type {
+            output.push_str(&format!(" ({})", event_type));
+        }
+
+        // Timestamp if available
+        if let Some(ref ts) = result.metadata.timestamp {
+            if !ts.is_empty() {
+                output.push_str(&format!(" @{}", ts));
+            }
+        }
+        output.push('\n');
+
+        // Content
+        output.push_str(&result.content);
+        output.push_str("\n\n");
+    }
+    output
+}

--- a/src/retrieval/engine.rs
+++ b/src/retrieval/engine.rs
@@ -1,0 +1,58 @@
+//! QueryEngine - parallel multi-oracle retrieval with RRF fusion
+
+use anyhow::Result;
+use rayon::prelude::*;
+
+use super::fusion::{rrf_fuse, FusedResult};
+use super::oracle::Oracle;
+use super::oracles::{LexicalOracle, PersonaOracle, SemanticOracle};
+
+/// Query engine that coordinates parallel oracle retrieval
+pub struct QueryEngine {
+    oracles: Vec<Box<dyn Oracle>>,
+}
+
+impl QueryEngine {
+    /// Create engine with default oracles (semantic, lexical, persona)
+    pub fn new() -> Self {
+        let oracles: Vec<Box<dyn Oracle>> = vec![
+            Box::new(SemanticOracle::new()),
+            Box::new(LexicalOracle::new()),
+            Box::new(PersonaOracle::new()),
+        ];
+
+        Self { oracles }
+    }
+
+    /// Query all available oracles in parallel, fuse with RRF
+    pub fn query(&self, query: &str, limit: usize) -> Result<Vec<FusedResult>> {
+        // Over-fetch from each oracle (2x limit) for better fusion
+        let fetch_limit = limit * 2;
+
+        // Query available oracles in parallel
+        let oracle_results: Vec<_> = self
+            .oracles
+            .par_iter()
+            .filter(|o| o.is_available())
+            .filter_map(|oracle| oracle.query(query, fetch_limit).ok())
+            .collect();
+
+        // Fuse with RRF (k=60 is standard)
+        Ok(rrf_fuse(oracle_results, 60, limit))
+    }
+
+    /// List available oracles
+    pub fn available_oracles(&self) -> Vec<&'static str> {
+        self.oracles
+            .iter()
+            .filter(|o| o.is_available())
+            .map(|o| o.name())
+            .collect()
+    }
+}
+
+impl Default for QueryEngine {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/retrieval/fusion.rs
+++ b/src/retrieval/fusion.rs
@@ -1,0 +1,136 @@
+//! Reciprocal Rank Fusion (RRF) for combining ranked lists
+//!
+//! RRF is a simple, effective method for fusing results from multiple retrievers.
+//! k=60 is the standard value from the original paper (Cormack et al., 2009).
+
+use std::collections::HashMap;
+
+use super::oracle::{OracleMetadata, OracleResult};
+
+/// Fused result with combined score and provenance
+#[derive(Debug)]
+pub struct FusedResult {
+    pub doc_id: String,
+    pub content: String,
+    pub fused_score: f32,
+    pub sources: Vec<&'static str>,
+    pub metadata: OracleMetadata,
+}
+
+/// Reciprocal Rank Fusion
+///
+/// Combines multiple ranked lists into a single ranking.
+/// Score for document d = Σ 1/(k + rank_i) for each list i containing d
+///
+/// k=60 is standard (higher k reduces impact of top ranks)
+pub fn rrf_fuse(ranked_lists: Vec<Vec<OracleResult>>, k: usize, limit: usize) -> Vec<FusedResult> {
+    let mut scores: HashMap<String, f32> = HashMap::new();
+    let mut docs: HashMap<String, OracleResult> = HashMap::new();
+    let mut sources: HashMap<String, Vec<&'static str>> = HashMap::new();
+
+    for list in ranked_lists {
+        for (rank, result) in list.into_iter().enumerate() {
+            // RRF score: 1 / (k + rank + 1)
+            // rank is 0-indexed, so rank 0 -> 1/(k+1)
+            let rrf_score = 1.0 / (k + rank + 1) as f32;
+
+            *scores.entry(result.doc_id.clone()).or_default() += rrf_score;
+
+            sources
+                .entry(result.doc_id.clone())
+                .or_default()
+                .push(result.source);
+
+            docs.entry(result.doc_id.clone()).or_insert(result);
+        }
+    }
+
+    // Sort by fused score descending
+    let mut fused: Vec<_> = scores
+        .into_iter()
+        .map(|(doc_id, fused_score)| {
+            let doc = docs.remove(&doc_id).unwrap();
+            let doc_sources = sources.remove(&doc_id).unwrap_or_default();
+            FusedResult {
+                doc_id,
+                content: doc.content,
+                fused_score,
+                sources: doc_sources,
+                metadata: doc.metadata,
+            }
+        })
+        .collect();
+
+    fused.sort_by(|a, b| {
+        b.fused_score
+            .partial_cmp(&a.fused_score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    fused.truncate(limit);
+    fused
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_result(doc_id: &str, source: &'static str) -> OracleResult {
+        OracleResult {
+            doc_id: doc_id.to_string(),
+            content: format!("Content for {}", doc_id),
+            source,
+            metadata: OracleMetadata::default(),
+        }
+    }
+
+    #[test]
+    fn test_rrf_single_list() {
+        // Results ordered by rank (first = rank 0, highest RRF score)
+        let lists = vec![vec![
+            make_result("doc_a", "semantic"),
+            make_result("doc_b", "semantic"),
+        ]];
+
+        let fused = rrf_fuse(lists, 60, 10);
+
+        assert_eq!(fused.len(), 2);
+        assert_eq!(fused[0].doc_id, "doc_a");
+        assert_eq!(fused[1].doc_id, "doc_b");
+        // Rank 0: 1/61, Rank 1: 1/62
+        assert!(fused[0].fused_score > fused[1].fused_score);
+    }
+
+    #[test]
+    fn test_rrf_multiple_lists_boost() {
+        // doc_b appears in both lists, should be boosted
+        let lists = vec![
+            vec![
+                make_result("doc_a", "semantic"),
+                make_result("doc_b", "semantic"),
+            ],
+            vec![
+                make_result("doc_b", "lexical"),
+                make_result("doc_c", "lexical"),
+            ],
+        ];
+
+        let fused = rrf_fuse(lists, 60, 10);
+
+        // doc_b should be first (appears in both lists)
+        assert_eq!(fused[0].doc_id, "doc_b");
+        assert_eq!(fused[0].sources.len(), 2);
+    }
+
+    #[test]
+    fn test_rrf_limit() {
+        let lists = vec![vec![
+            make_result("doc_a", "semantic"),
+            make_result("doc_b", "semantic"),
+            make_result("doc_c", "semantic"),
+        ]];
+
+        let fused = rrf_fuse(lists, 60, 2);
+
+        assert_eq!(fused.len(), 2);
+    }
+}

--- a/src/retrieval/mod.rs
+++ b/src/retrieval/mod.rs
@@ -1,0 +1,17 @@
+//! Retrieval module - multi-oracle knowledge retrieval with RRF fusion
+//!
+//! Public interface:
+//! - `QueryEngine` for parallel multi-oracle queries
+//! - `FusedResult` for query results (includes metadata)
+//!
+//! Internal (not exported):
+//! - `Oracle` trait and implementations (semantic, lexical, persona)
+//! - RRF fusion algorithm
+
+mod engine;
+mod fusion;
+mod oracle;
+mod oracles;
+
+pub use engine::QueryEngine;
+pub use fusion::FusedResult;

--- a/src/retrieval/oracle.rs
+++ b/src/retrieval/oracle.rs
@@ -1,0 +1,42 @@
+//! Oracle trait and types for multi-dimensional retrieval
+//!
+//! Oracles are internal retrieval strategies (not external adapters).
+//! Each oracle queries one knowledge dimension and returns ranked results.
+
+use anyhow::Result;
+
+/// Result from a single oracle query
+#[derive(Debug, Clone)]
+pub struct OracleResult {
+    /// Unique document identifier (for deduplication in fusion)
+    pub doc_id: String,
+    /// Content snippet or summary
+    pub content: String,
+    /// Source oracle name
+    pub source: &'static str,
+    /// Additional metadata
+    pub metadata: OracleMetadata,
+}
+
+/// Metadata attached to oracle results
+#[derive(Debug, Clone, Default)]
+pub struct OracleMetadata {
+    pub file_path: Option<String>,
+    pub timestamp: Option<String>,
+    pub event_type: Option<String>,
+}
+
+/// Oracle interface - each retrieval dimension implements this
+///
+/// This is a strategy pattern (not adapter pattern) because oracles
+/// are internal retrieval mechanisms, not external system integrations.
+pub trait Oracle: Send + Sync {
+    /// Oracle name for provenance tracking
+    fn name(&self) -> &'static str;
+
+    /// Query the oracle, returning ranked results
+    fn query(&self, query: &str, limit: usize) -> Result<Vec<OracleResult>>;
+
+    /// Whether this oracle is available (index exists, etc.)
+    fn is_available(&self) -> bool;
+}

--- a/src/retrieval/oracles/lexical.rs
+++ b/src/retrieval/oracles/lexical.rs
@@ -1,0 +1,58 @@
+//! Lexical oracle - BM25/FTS5 text search
+
+use anyhow::Result;
+use std::path::PathBuf;
+
+use crate::commands::scry::{scry_lexical, ScryOptions};
+use crate::retrieval::oracle::{Oracle, OracleMetadata, OracleResult};
+
+pub struct LexicalOracle {
+    db_path: PathBuf,
+}
+
+impl LexicalOracle {
+    pub fn new() -> Self {
+        Self {
+            db_path: PathBuf::from(".patina/data/patina.db"),
+        }
+    }
+}
+
+impl Oracle for LexicalOracle {
+    fn name(&self) -> &'static str {
+        "lexical"
+    }
+
+    fn query(&self, query: &str, limit: usize) -> Result<Vec<OracleResult>> {
+        let options = ScryOptions {
+            limit,
+            include_persona: false,
+            ..Default::default()
+        };
+
+        let results = scry_lexical(query, &options)?;
+        let source = self.name();
+
+        Ok(results
+            .into_iter()
+            .map(|r| OracleResult {
+                doc_id: r.source_id.clone(),
+                content: r.content,
+                source,
+                metadata: OracleMetadata {
+                    file_path: Some(r.source_id),
+                    timestamp: if r.timestamp.is_empty() {
+                        None
+                    } else {
+                        Some(r.timestamp)
+                    },
+                    event_type: Some(r.event_type),
+                },
+            })
+            .collect())
+    }
+
+    fn is_available(&self) -> bool {
+        self.db_path.exists()
+    }
+}

--- a/src/retrieval/oracles/mod.rs
+++ b/src/retrieval/oracles/mod.rs
@@ -1,0 +1,12 @@
+//! Concrete oracle implementations
+//!
+//! These wrap existing scry/persona functions as Oracle trait implementations.
+//! Not exposed publicly - QueryEngine constructs them internally.
+
+mod lexical;
+mod persona;
+mod semantic;
+
+pub(crate) use lexical::LexicalOracle;
+pub(crate) use persona::PersonaOracle;
+pub(crate) use semantic::SemanticOracle;

--- a/src/retrieval/oracles/persona.rs
+++ b/src/retrieval/oracles/persona.rs
@@ -1,0 +1,52 @@
+//! Persona oracle - cross-project user knowledge
+
+use anyhow::Result;
+use std::path::PathBuf;
+
+use crate::commands::persona;
+use crate::retrieval::oracle::{Oracle, OracleMetadata, OracleResult};
+
+pub struct PersonaOracle {
+    db_path: PathBuf,
+}
+
+impl PersonaOracle {
+    pub fn new() -> Self {
+        let persona_dir = dirs::home_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join(".patina/personas/default/materialized");
+
+        Self {
+            db_path: persona_dir.join("persona.db"),
+        }
+    }
+}
+
+impl Oracle for PersonaOracle {
+    fn name(&self) -> &'static str {
+        "persona"
+    }
+
+    fn query(&self, query: &str, limit: usize) -> Result<Vec<OracleResult>> {
+        let results = persona::query(query, limit, 0.0, None)?;
+        let source = self.name();
+
+        Ok(results
+            .into_iter()
+            .map(|r| OracleResult {
+                doc_id: format!("{}:{}:{}", source, r.source, r.timestamp),
+                content: r.content,
+                source,
+                metadata: OracleMetadata {
+                    file_path: None,
+                    timestamp: Some(r.timestamp),
+                    event_type: Some(r.source),
+                },
+            })
+            .collect())
+    }
+
+    fn is_available(&self) -> bool {
+        self.db_path.exists()
+    }
+}

--- a/src/retrieval/oracles/semantic.rs
+++ b/src/retrieval/oracles/semantic.rs
@@ -1,0 +1,63 @@
+//! Semantic oracle - E5 embeddings + USearch vector search
+
+use anyhow::Result;
+use std::path::PathBuf;
+
+use crate::commands::scry::{scry_text, ScryOptions};
+use crate::retrieval::oracle::{Oracle, OracleMetadata, OracleResult};
+
+pub struct SemanticOracle {
+    db_path: PathBuf,
+    index_path: PathBuf,
+}
+
+impl SemanticOracle {
+    pub fn new() -> Self {
+        Self {
+            db_path: PathBuf::from(".patina/data/patina.db"),
+            index_path: PathBuf::from(
+                ".patina/data/embeddings/e5-base-v2/projections/semantic.usearch",
+            ),
+        }
+    }
+}
+
+impl Oracle for SemanticOracle {
+    fn name(&self) -> &'static str {
+        "semantic"
+    }
+
+    fn query(&self, query: &str, limit: usize) -> Result<Vec<OracleResult>> {
+        let options = ScryOptions {
+            limit,
+            dimension: Some("semantic".to_string()),
+            include_persona: false, // Persona is separate oracle
+            ..Default::default()
+        };
+
+        let results = scry_text(query, &options)?;
+        let source = self.name();
+
+        Ok(results
+            .into_iter()
+            .map(|r| OracleResult {
+                doc_id: r.source_id.clone(),
+                content: r.content,
+                source,
+                metadata: OracleMetadata {
+                    file_path: Some(r.source_id),
+                    timestamp: if r.timestamp.is_empty() {
+                        None
+                    } else {
+                        Some(r.timestamp)
+                    },
+                    event_type: Some(r.event_type),
+                },
+            })
+            .collect())
+    }
+
+    fn is_available(&self) -> bool {
+        self.index_path.exists() && self.db_path.exists()
+    }
+}


### PR DESCRIPTION
## Summary

Completes Phase 2 implementation: Agentic RAG system with MCP server integration.

### New Features
- **Oracle Abstraction** (`src/retrieval/`) - Strategy pattern for multi-dimensional retrieval
  - Semantic oracle (E5 + USearch)
  - Lexical oracle (BM25/FTS5)
  - Persona oracle (session knowledge)
- **RRF Fusion** - Reciprocal Rank Fusion (k=60) for combining ranked lists
- **MCP Server** (`src/mcp/`) - JSON-RPC 2.0 over stdio for Claude Code integration
  - `patina_query` tool with hybrid retrieval
  - Rich output format (file path, event type, timestamp)
- **One-Command Setup** - `patina adapter mcp claude` configures Claude Code

### Bug Fixes (found during code review)
- Fixed `doc_id` prefix breaking cross-oracle RRF boosting
- Added JSON-RPC version validation
- Removed dead code (unused `score`, `line_number` fields)

### Documentation
- Phase 2 spec: `layer/surface/build/spec-agentic-rag.md`
- Phase 2.5 roadmap: Lab readiness for experimentation
- Updated `layer/core/build.md` with completion status

### Design Decisions
- Hand-rolled MCP (~150 lines) vs external SDK - simpler, no async dependency
- Parallel retrieval + RRF fusion vs local LLM routing - research shows better results
- "Use it or remove it" - no `#[allow(dead_code)]` annotations

## Test Plan
- [x] All 159 tests pass
- [x] Pre-push checks (fmt, clippy, test) pass
- [ ] Live test with Claude Code MCP integration (next session)

## Commits
- `feat(retrieval): add Oracle abstraction with RRF fusion`
- `feat(mcp): add MCP server with patina_query tool`
- `feat(adapter): add mcp subcommand for Claude setup`
- `docs(build): add Phase 2 agentic RAG spec and roadmap`
- `docs(build): mark Phase 2 complete, add Phase 2.5 lab readiness`