### PR TITLE
ci: add release-plz for automated releases

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,45 @@
+# release-plz.yml - Automated versioning and GitHub releases
+#
+# How it works:
+# 1. Push to main with conventional commits (feat:, fix:, docs:)
+# 2. release-plz creates a "Release PR" with version bump + changelog
+# 3. Merge the Release PR -> GitHub Release created automatically
+#
+# Conventional commit prefixes:
+# - feat: -> minor version bump (0.1.0 -> 0.2.0)
+# - fix:  -> patch version bump (0.1.0 -> 0.1.1)
+# - docs: -> no version bump (changelog only)
+# - BREAKING CHANGE: -> major version bump (0.1.0 -> 1.0.0)
+#
+# Note: crates.io publishing is disabled in release-plz.toml
+
+name: Release-plz
+
+permissions:
+  pull-requests: write
+  contents: write
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: release-plz-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-plz:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run release-plz
+        uses: release-plz/release-plz-action@v0.5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,15 @@
+# release-plz configuration
+# Docs: https://release-plz.dev/docs/config
+
+[workspace]
+# Disable crates.io publishing - GitHub releases only
+publish = false
+
+# Create git tags for releases
+git_tag_enable = true
+
+# Create GitHub releases
+git_release_enable = true
+
+# Don't run semver checks (we're not publishing to crates.io)
+semver_check = false


### PR DESCRIPTION
## Summary

Add release-plz workflow for automated GitHub releases.

## Changes

- **`release-plz.toml`**: Configuration with `publish = false` (GitHub only, no crates.io)
- **`.github/workflows/release-plz.yml`**: Workflow triggered on push to main

## How It Works

1. Push conventional commits to main (via PR merge)
2. release-plz creates a "Release PR" with version bump + changelog
3. Merge the Release PR → GitHub Release created automatically

## Conventional Commits

- `feat:` → minor bump (0.1.0 → 0.2.0)
- `fix:` → patch bump (0.1.0 → 0.1.1)
- `docs:` → changelog only, no bump
- `BREAKING CHANGE:` → major bump

## Test Plan

- [x] `cargo fmt` passes
- [x] `cargo clippy` passes
- [x] `cargo test` passes
- [ ] Workflow runs on merge to main
- [ ] Release PR created after next conventional commit