### PR TITLE
fix(ci): update release-plz action + secrets v2 implementation

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -40,6 +40,6 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Run release-plz
-        uses: release-plz/release-plz-action@v0.5
+        uses: release-plz/action@v0.5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- fix(ci): update release-plz action to new repo location (`release-plz/action` vs old `release-plz/release-plz-action`)
- feat(secrets): complete v2 implementation with age encryption + macOS Keychain
- fix(secrets): CI compatibility fixes for cross-platform builds

## Key Changes
- **release-plz fix**: Action moved from `release-plz/release-plz-action` to `release-plz/action`
- **secrets v2**: Local vault with age encryption, replacing 1Password dependency
- **CI fixes**: Keychain constants now macOS-only for Linux CI compatibility

## Test plan
- [x] All 195 tests pass locally
- [x] Clippy clean
- [x] Formatting clean
- [ ] CI workflow validates on merge