### PR TITLE
docs: update all front-facing docs for v0.17.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,10 @@ A tool that captures and evolves development patterns, making AI assistants smar
 Patina accumulates knowledge like the protective layer that forms on metal - your development wisdom builds up over time and transfers between projects.
 
 ## Architecture
-- **Layer**: Pattern evolution system (Core → Surface → Dust)
-- **Adapters**: LLM-agnostic interfaces (Claude, Gemini) 
-- **Environments**: Modular workspace system with container orchestration
+- **Layer**: Pattern evolution system (Core → Surface → Dust) with epistemic beliefs
+- **Adapters**: LLM-agnostic interfaces (Claude, Gemini, OpenCode)
+- **Mother**: Cross-project daemon with graph routing, WASM plugin children
+- **Plugin System**: WebAssembly Component Model (WIT) for extensibility
 - **Philosophy**: Decompose systems into tools that LLMs can build
 
 ## Design Documents
@@ -32,7 +33,6 @@ Patina accumulates knowledge like the protective layer that forms on metal - you
   - Cross-platform: Same vector space on Mac/Linux/Windows
   - Production-proven: Twitter scale (`ort`), Hugging Face (fastembed)
 - Rust for CLI and core logic - let the compiler be your guard rail
-- Docker for containerized builds and tests
 - Patterns evolve from projects → topics → core
 - Always provide escape hatches
 
@@ -69,48 +69,62 @@ The CI will fail if any of these checks don't pass! The pre-push script runs all
 patina init <name>              # Initialize new project skeleton
 patina init .                   # Re-init/update current project
 patina adapter add claude       # Add LLM adapter support
+patina doctor                   # Check project health
 
-# Development
-patina doctor               # Check project health
-patina scrape               # Build semantic knowledge database
-patina yolo                 # Generate devcontainer (if needed)
+# Knowledge pipeline
+patina scrape                   # Build semantic knowledge database
+patina oxidize                  # Build embedding projections
+patina rebuild                  # Rebuild .patina/ from git-tracked sources
+
+# Search & retrieval
+patina scry "query"             # Semantic vector search
+patina assay                    # Structural queries (imports, callers, etc.)
+patina context                  # Get project patterns and beliefs
+
+# Spec-driven development
+patina spec ready               # Show specs ready to work
+patina spec status <name> active  # Update spec status
+patina version                  # Show version + ready specs
 
 # Session Management (Claude adapter)
-/session-git-start <name>       # Begin development session
-/session-git-update             # Track progress
-/session-git-note <insight>     # Capture insights
-/session-git-end                # Distill learnings
-
+/session-start <name>           # Begin development session
+/session-update                 # Track progress
+/session-note <insight>         # Capture insights
+/session-end                    # Distill learnings
 ```
-
-## Build System
-- Uses Docker for containerized builds
-- Never requires specific tools beyond Docker
-- Clear feedback about what's being used
 
 ## Project Structure
 ```
 patina/
-├── src/                    # Rust source (CLI and core logic)
-│   ├── adapters/          # LLM adapters (Claude, Gemini)
-│   ├── commands/          # CLI commands
-│   └── indexer/           # Pattern indexing with Git awareness
-├── layer/                  # Pattern storage (Git as memory)
-│   ├── core/              # Eternal patterns (dependable-rust, etc)
-│   ├── surface/           # Active development & architecture docs
-│   ├── dust/              # Historical/archived patterns
-│   └── sessions/          # Distilled session knowledge
-└── resources/             # Templates and scripts
-    ├── claude/            # Claude adapter resources (session/git scripts)
-    ├── gemini/            # Gemini adapter resources
-    └── templates/         # Docker templates
+├── src/                        # Rust source (~61k lines, 195 files)
+│   ├── commands/               # CLI commands (27 total)
+│   ├── plugin/                 # WASM plugin engine (wasmtime)
+│   ├── mother/                 # Daemon core (graph, children)
+│   ├── retrieval/              # Oracle abstraction, RRF fusion
+│   ├── mcp/                    # MCP protocol, JSON-RPC server
+│   ├── embeddings/             # ONNX E5-base-v2, USearch HNSW
+│   ├── release/                # Release strategy and version bumping
+│   ├── secrets/                # Age encryption, Keychain integration
+│   ├── adapters/               # LLM adapters (Claude, Gemini, OpenCode)
+│   └── ...                     # db, forge, git, models, scanner, workspace
+├── patina-metal/               # Tree-sitter grammars (9 languages)
+├── patina-doctor/              # Doctor as WASM plugin
+├── patina-plugin-api/          # Guest-side WASM bindings
+├── patina-command-api/         # Command world guest API
+├── layer/                      # Pattern storage (Git as memory)
+│   ├── core/                   # Eternal patterns + core beliefs
+│   ├── surface/                # Specs, architecture, epistemic beliefs
+│   ├── dust/                   # Archived patterns
+│   └── sessions/               # Session archives
+└── resources/                  # Templates and adapter scripts
 ```
 
 ## Design Philosophy
-1. **Knowledge First**: Patterns are the core value
-2. **LLM Agnostic**: Work where the AI lives
-3. **Container Native**: Reproducible everywhere
-4. **Escape Hatches**: Never lock users in
+1. **Knowledge First**: Patterns and beliefs are the core value
+2. **LLM Agnostic**: Adapter pattern — work where the AI lives
+3. **Pure Rust, Local-first**: SQLite + ONNX + USearch, no cloud required
+4. **Spec-driven**: Features start as specs, go through lifecycle, trigger releases
+5. **Escape Hatches**: Never lock users in
 
 ## Git Discipline
 
@@ -118,11 +132,11 @@ patina/
 
 - Commit after completing each logical change
 - One commit = one purpose (fix one bug, add one feature, refactor one function)
-- Run `/session-git-update` frequently to monitor uncommitted changes
+- Run `/session-update` frequently to monitor uncommitted changes
 - If warned about old uncommitted changes, commit immediately
 - Prefer `git add -p` for surgical staging when files have multiple changes
 
-### Session-Git Commands
+### Session Commands
 - Integrated Git workflow into session tracking
 - Automatic tagging at session boundaries
 - Work classification based on Git metrics

--- a/README.md
+++ b/README.md
@@ -8,19 +8,24 @@ Patina accumulates development wisdom like the protective layer that forms on me
 
 Patina solves the fundamental problem of AI-assisted development: constantly re-teaching AI assistants about your project's context, patterns, and constraints.
 
-**Core idea**: Your development knowledge compounds. Session insights become observations, observations train embeddings, embeddings enable smarter retrieval.
+**Core idea**: Your development knowledge compounds. Session insights become beliefs, beliefs ground retrieval, retrieval enables smarter AI assistance.
 
-## Features (v0.8.1)
+## Features (v0.17.0)
 
 | Feature | Description |
 |---------|-------------|
-| **Unified Eventlog** | Code AST, git history, sessions → single patina.db |
-| **Multi-Dimension Search** | Semantic, temporal, dependency projections |
-| **Cross-Project Knowledge** | Query external repos via `~/.patina/repos/` |
-| **GitHub Integration** | Index issues with bounty detection |
-| **Mother Daemon** | `patina serve` for container queries |
+| **Semantic Search** | Vector search over code, commits, beliefs, and patterns via `scry` |
+| **Structural Queries** | Module inventory, call graph, imports, co-change analysis via `assay` |
+| **Epistemic Beliefs** | Capture project decisions with evidence, grounding, and attack/support relationships |
+| **WASM Plugins** | Extend Patina with WebAssembly component model plugins |
+| **Mother Daemon** | Cross-project knowledge, hot model caching, graph routing |
+| **MCP Integration** | Model Context Protocol server for LLM tool integration |
+| **Cross-Project Knowledge** | Query external repos and persona knowledge across projects |
+| **Spec-Driven Development** | Lifecycle management for specs (draft → ready → active → complete) |
+| **Session Tracking** | Git-integrated development sessions with tagging and classification |
+| **Secrets Management** | Age encryption with Touch ID, multi-recipient vaults |
+| **LLM Adapters** | Claude, Gemini, and OpenCode integration |
 | **YOLO Devcontainers** | AI-ready development environments |
-| **LLM Adapters** | Claude and Gemini integration |
 
 ## Quick Start
 
@@ -28,23 +33,35 @@ Patina solves the fundamental problem of AI-assisted development: constantly re-
 # Install
 cargo install --path .
 
-# Initialize project with Claude adapter
-patina init . --llm=claude
+# Initialize project
+patina init .
+
+# Add an LLM adapter
+patina adapter add claude
 
 # Build knowledge database (code + git + sessions)
 patina scrape
 
-# Train embedding projections
+# Build embedding projections
 patina oxidize
 
 # Search your codebase
-patina scry "error handling patterns"    # Semantic search
-patina scry "find spawn_entity"          # Exact match (FTS5)
-patina scry --file src/main.rs           # Temporal: co-changing files
+patina scry "error handling patterns"        # Semantic search
+patina scry --file src/main.rs               # Temporal: co-changing files
+patina scry --belief measure-first           # Belief grounding: find related code
+
+# Structural queries
+patina assay                                 # Module inventory
+patina assay search "plugin engine"          # FTS5 text search
+patina assay cochange src/main.rs            # Co-change analysis
+
+# Get project patterns and beliefs
+patina context                               # Core + surface patterns
+patina context --topic "error handling"      # Focused on a topic
 
 # Query external repos
-patina repo dojoengine/dojo              # Clone + index
-patina scry "spawn" --repo dojo          # Search it
+patina repo dojoengine/dojo                  # Clone + index
+patina scry "spawn" --repo dojo              # Search it
 
 # Check project health
 patina doctor
@@ -59,19 +76,47 @@ patina scrape code                  # Extract AST, call graph, symbols
 patina scrape git                   # Extract commits, file co-changes
 patina scrape sessions              # Extract session observations
 
-patina oxidize                      # Train projections from .patina/oxidize.yaml
+patina oxidize                      # Build vector embeddings from scraped data
+patina rebuild                      # Rebuild .patina/ from git-tracked sources
 ```
 
 Supported languages: Rust, TypeScript, JavaScript, Python, Go, C, C++, Solidity, Cairo
 
-### Search (scry)
+### Search & Retrieval
+
+**Semantic search (scry)** — vector similarity over beliefs, patterns, commits, and code:
 ```bash
 patina scry "error handling"                       # Semantic search
-patina scry "find MyClass::new"                    # FTS5 exact match (auto-detected)
 patina scry --file src/auth.rs                     # Temporal: what files co-change?
-patina scry --dimension dependency "execute"       # Call graph relationships
+patina scry --belief eventlog-is-truth             # Belief grounding
 patina scry --repo dojo "spawn"                    # Query external repo
 patina scry --include-issues "bounty"              # Include GitHub issues
+patina scry orient src/commands/                   # Structural orientation
+patina scry recent --days 7                        # Recent changes
+```
+
+**Structural queries (assay)** — exact queries over code structure:
+```bash
+patina assay                                       # Module inventory
+patina assay imports src/main.rs                   # What does main.rs import?
+patina assay callers "find_project_root"            # Who calls this function?
+patina assay cochange src/plugin/mod.rs            # Files that co-change
+patina assay search "embedding model"              # FTS5 ranked text search
+patina assay belief eventlog-is-truth              # Evidence for a belief
+patina assay derive                                # Compute structural signals
+```
+
+**Context** — patterns and conventions for AI assistants:
+```bash
+patina context                                     # Core + surface patterns + beliefs
+patina context --topic "testing"                   # Focused retrieval
+```
+
+### Epistemic Beliefs
+```bash
+patina belief audit                 # Show all beliefs with use/truth metrics
+patina scry --belief <id>           # Ground a belief against code
+patina assay belief <id>            # Find evidence for a belief
 ```
 
 ### Cross-Project Knowledge
@@ -80,21 +125,68 @@ patina repo dojoengine/dojo              # Clone + scrape to ~/.patina/repos/
 patina repo add <url> --with-issues      # Also fetch GitHub issues
 patina repo list                         # Show registered repos
 patina repo update dojo                  # Git pull + rescrape
-patina repo rm dojo                      # Remove repo
+patina repo remove dojo                  # Remove repo
+
+patina persona note "prefers explicit error handling"  # Capture user knowledge
+patina persona query "error handling"                  # Search persona knowledge
 ```
 
 ### Mother Daemon
 ```bash
-patina serve                             # Start on localhost:50051
-patina serve --host 0.0.0.0              # Bind all interfaces (for containers)
-curl http://localhost:50051/health       # Health check
+patina mother start                      # Start the daemon
+patina mother status                     # Show daemon status
+patina mother graph                      # Graph operations
+```
+
+### WASM Plugins
+```bash
+patina plugin list                       # List installed plugins
+```
+
+Plugins use the WebAssembly Component Model (WIT interfaces). Patina ships with `patina-doctor` as a WASM plugin with a compiled fallback.
+
+### Session Management
+```bash
+patina session start "feature name"      # Start session with git tagging
+patina session update                    # Record progress with git metrics
+patina session note "important insight"  # Add timestamped note
+patina session end                       # Archive, classify, distill
+```
+
+Within Claude, use slash commands: `/session-start`, `/session-update`, `/session-note`, `/session-end`
+
+### Spec Lifecycle
+```bash
+patina spec list                         # List all specs
+patina spec ready                        # Show unblocked specs ready to work
+patina spec blocked                      # Show blocked specs
+patina spec status <name> active         # Update status (draft → ready → active → complete)
+patina spec archive <name>               # Archive completed spec
+```
+
+### Versioning & Release
+```bash
+patina version                           # Show current version + ready specs
+patina version --components              # Show component versions
+patina version hotfix                    # Emergency patch bump
+patina spec status <name> complete       # Completing a spec triggers release
+```
+
+### Secrets
+```bash
+patina secrets add API_KEY               # Add secret to vault
+patina secrets run -- ./my-script.sh     # Inject secrets into environment
+patina secrets check                     # Scan staged files for exposed secrets
+patina secrets audit                     # Scan all tracked files
 ```
 
 ### Project Setup
 ```bash
-patina init . --llm=claude         # Initialize with Claude adapter
+patina init .                      # Initialize project
+patina adapter add claude          # Add LLM adapter
 patina doctor                      # Check project health
-patina version                     # Show version info
+patina upgrade                     # Check for new CLI versions
+patina model list                  # List available embedding models
 ```
 
 ### Development Environment
@@ -103,122 +195,65 @@ patina yolo                         # Generate AI-ready devcontainer
 patina yolo --with foundry,cairo    # Add specific tools
 ```
 
-### Session Management (Claude Adapter)
-
-Within Claude, use these slash commands:
-- `/session-start <name>` - Begin session with Git tracking
-- `/session-update` - Capture progress
-- `/session-note <insight>` - Record insight
-- `/session-end` - Archive and distill learnings
-
-## Command Reference
-
-Patina has 20 commands totaling ~42k lines of Rust. Here's the full inventory:
-
-### Active Commands
-
-| Command | Lines | Module | Description |
-|---------|------:|--------|-------------|
-| `scrape` | 11,800 | `scrape/` | Extract code, git, sessions, layer to SQLite |
-| `scry` | 2,200 | `scry/` | Hybrid search (semantic + lexical + temporal) - 7 internal modules |
-| `secrets` | 2,100 | `secrets/` | Age encryption, Touch ID, multi-recipient vaults |
-| `oxidize` | 1,800 | `oxidize/` | Build vector embeddings from scraped data |
-| `yolo` | 1,600 | `yolo/` | AI-ready devcontainer generation |
-| `init` | 1,200 | `init/` | Initialize project with LLM adapter |
-| `repo` | 1,100 | `repo/` | Register external repos for cross-project search |
-| `assay` | 1,000 | `assay/` | Structural queries (imports, callers, inventory) |
-| `git` | 700 | `scrape/git/` | Git history and co-change extraction |
-| `doctor` | 600 | `doctor.rs` | Health check and diagnostics |
-| `persona` | 600 | `persona/` | Cross-project user knowledge |
-| `adapter` | 400 | `adapter.rs` | LLM frontend management (Claude, Gemini) |
-| `serve` | 300 | `serve/` | MCP server for LLM tool integration |
-| `rebuild` | 260 | `rebuild/` | Rebuild .patina/ from git-tracked sources |
-| `model` | 210 | `model.rs` | Manage embedding models in mother cache |
-| `upgrade` | 160 | `upgrade.rs` | Check for new CLI versions |
-| `version` | 160 | `version.rs` | Show version and component info |
-
-### Scrape Sub-modules
-
-The `scrape` command is the largest, with tree-sitter AST parsing for 9 languages:
-
-| Sub-module | Lines | Purpose |
-|------------|------:|---------|
-| `code/languages/` | 5,600 | Language parsers (TS, C++, JS, Go, Sol, Py, Rust, C, Cairo) |
-| `code/` | 1,500 | Extraction pipeline, database, types |
-| `git/` | 700 | Git history, co-change relationships |
-| `sessions/` | 540 | Session markdown files |
-| `layer/` | 420 | Layer pattern markdown files |
-| `github/` | 340 | GitHub issues via `gh` CLI |
-
-### Measurement Tools
-
-| Command | Lines | Purpose |
-|---------|------:|---------|
-| `eval` | 600 | Retrieval quality evaluation |
-| `bench` | 450 | Benchmarking with ground truth |
-
-### Build Wrappers
-
-| Command | Lines | Purpose |
-|---------|------:|---------|
-| `build` | 32 | Build in dev environment (Docker/Dagger/Native) |
-| `test` | 31 | Run tests in dev environment |
-
-### Shared Infrastructure
-
-| Crate/Module | Lines | Purpose |
-|--------------|------:|---------|
-| `patina-metal/` | 1,000 | Tree-sitter grammars, unified parser |
-| `retrieval/` | 2,500 | Oracle abstraction, RRF fusion |
-| `mcp/` | 1,600 | MCP protocol, JSON-RPC server |
-| `storage/` | 1,200 | SQLite eventlog, materialized views |
-| `embeddings/` | 900 | ONNX E5-base-v2, USearch HNSW |
-
-### Codebase Summary
-
-| Category | Lines |
-|----------|------:|
-| Commands (20 total) | ~24,000 |
-| Shared infrastructure | ~7,200 |
-| patina-metal crate | ~1,000 |
-| main.rs + lib glue | ~1,200 |
-| Tests | ~7,500 |
-| **Total** | **~41,000** |
+### Measurement
+```bash
+patina eval                         # Evaluate retrieval quality
+patina bench                        # Benchmark with ground truth
+patina report                       # Generate project state report
+```
 
 ## Architecture
 
 ```
 patina/
-├── src/
-│   ├── commands/
-│   │   ├── scrape/        # Code, git, sessions, GitHub extraction
-│   │   ├── oxidize/       # MLP training (semantic, temporal, dependency)
-│   │   ├── scry/          # Unified query interface
-│   │   │   ├── mod.rs     # Public API (~220 lines)
-│   │   │   └── internal/  # Implementation (7 modules)
-│   │   │       ├── search.rs, hybrid.rs, subcommands.rs
-│   │   │       ├── routing.rs, enrichment.rs, logging.rs
-│   │   │       └── query_prep.rs
-│   │   ├── repo/          # Cross-project knowledge
-│   │   └── serve/         # Mother HTTP daemon
-│   ├── embeddings/        # ONNX E5-base-v2 embeddings
-│   └── reasoning/         # Embedded Prolog for belief validation
-├── layer/
-│   ├── core/              # Eternal principles, build.md roadmap
-│   ├── surface/           # Specs, design docs
-│   └── sessions/          # Session archives (Git-tracked)
+├── src/                        # Rust source (~61k lines, 195 files)
+│   ├── commands/               # CLI commands (27 total)
+│   │   ├── scrape/             # Code, git, sessions, GitHub extraction
+│   │   ├── scry/               # Semantic vector search
+│   │   ├── assay/              # Structural queries (imports, callers, co-change)
+│   │   ├── oxidize/            # Embedding projection training
+│   │   ├── mother/             # Daemon (microserver, registry, graph)
+│   │   ├── session/            # Git-integrated session management
+│   │   ├── repo/               # Cross-project knowledge
+│   │   ├── spec/               # Spec lifecycle management
+│   │   ├── version/            # Versioning and release
+│   │   ├── belief/             # Epistemic belief audit
+│   │   ├── persona/            # Cross-project user knowledge
+│   │   └── ...                 # init, doctor, secrets, yolo, eval, bench, etc.
+│   ├── plugin/                 # WASM plugin engine (wasmtime)
+│   ├── mother/                 # Daemon core (graph, children)
+│   ├── retrieval/              # Oracle abstraction, RRF fusion
+│   ├── mcp/                    # MCP protocol, JSON-RPC server
+│   ├── embeddings/             # ONNX E5-base-v2, USearch HNSW
+│   ├── release/                # Release strategy and version bumping
+│   ├── secrets/                # Age encryption, Keychain integration
+│   ├── adapters/               # LLM adapters (Claude, Gemini, OpenCode)
+│   └── ...                     # db, forge, git, models, scanner, workspace
+├── patina-metal/               # Tree-sitter grammars, unified parser
+├── patina-plugin-api/          # Guest-side WASM bindings
+├── patina-command-api/         # Command world guest API
+├── patina-doctor/              # Doctor as WASM plugin
+├── patina-plugin-models/       # Models WASM plugin
+├── patina-plugin-repos/        # Repos WASM plugin
+├── layer/                      # Pattern storage (Git as memory)
+│   ├── core/                   # Eternal principles + core beliefs
+│   ├── surface/                # Active specs, architecture docs
+│   │   ├── epistemic/beliefs/  # 103 epistemic beliefs
+│   │   └── build/              # Specs and roadmap
+│   ├── dust/                   # Archived patterns
+│   └── sessions/               # 657 session archives
 ├── .patina/
 │   ├── data/
-│   │   ├── patina.db      # Unified eventlog + materialized views
+│   │   ├── patina.db           # Unified eventlog + materialized views
 │   │   └── embeddings/e5-base-v2/projections/
-│   │       ├── semantic.safetensors   # Trained MLP weights
-│   │       ├── semantic.usearch       # HNSW vector index
+│   │       ├── semantic.*      # Trained MLP weights + HNSW index
 │   │       ├── temporal.*
 │   │       └── dependency.*
-│   └── oxidize.yaml       # Projection training recipe
+│   └── oxidize.yaml            # Projection training recipe
 └── ~/.patina/
-    ├── repos/             # External repos (cross-project knowledge)
-    └── registry.yaml      # Repo registry
+    ├── repos/                  # External repos (cross-project knowledge)
+    ├── layer/                  # User-level beliefs and persona
+    └── registry.yaml           # Repo registry
 ```
 
 ### Data Flow
@@ -226,63 +261,36 @@ patina/
 ```
 Sources                    Scrape              Oxidize              Query
 ───────                    ──────              ───────              ─────
-.git/commits          →    patina.db     →    Training pairs   →   scry
-src/**/* (AST)        →    ├── eventlog  →    E5 embedding     →   ├── semantic
-layer/sessions/*.md   →    ├── call_graph →   MLP projection   →   ├── temporal
-GitHub issues         →    ├── co_changes→    USearch HNSW     →   └── dependency
-                           └── code_fts       (.usearch files)
+.git/commits          →    patina.db     →    Training pairs   →   scry (semantic)
+src/**/* (AST)        →    ├── eventlog  →    E5 embedding     →   assay (structural)
+layer/sessions/*.md   →    ├── call_graph →   MLP projection   →   context (patterns)
+layer/**/beliefs/*.md →    ├── co_changes→    USearch HNSW     →   belief audit
+GitHub issues         →    └── code_fts       (.usearch files)
 ```
 
 ### Embedding Model
 
 Patina uses **E5-base-v2** (768-dim) with trained MLP projections per dimension.
 
-Configure in `.patina/config.toml`:
-```toml
-[embeddings]
-model = "e5-base-v2"
-```
+| Dimension | Training Signal | Query Interface |
+|-----------|-----------------|-----------------|
+| Semantic | Same session = related | `scry "query"` (text → concepts) |
+| Temporal | Same commit = related | `scry --file src/foo.rs` (file → co-changers) |
+| Dependency | Caller/callee = related | `assay callers/callees` (call graph) |
+
+**Architecture:** E5-base-v2 (768-dim) → trained MLP (768→1024→256) → USearch HNSW index per dimension.
 
 ## Design Principles
 
 - **Pure Rust**: No Python subprocess dependencies (ONNX Runtime via `ort` crate)
-- **No async**: Blocking I/O with rayon for parallelism, rouille for HTTP server
 - **Local-first**: SQLite + USearch, no cloud services required
-- **LLM-agnostic**: Adapter pattern for Claude, Gemini, etc.
-- **Git as memory**: Sessions committed to repo, vectors rebuildable from source
-
-## Multidimensional Embeddings
-
-Patina uses **separate dimension projections** rather than a single embedding space. Each dimension is an independent 256-dim projection trained on different relationship signals:
-
-| Dimension | Training Signal | Status | Query Interface |
-|-----------|-----------------|--------|-----------------|
-| Semantic | Same session = related | ✅ Done | `scry "query"` (text→concepts) |
-| Temporal | Same commit = related | ✅ Done | `scry --file src/foo.rs` (file→co-changers) |
-| Dependency | Caller/callee = related | ✅ Done | `scry --dimension dependency` (func→call graph) |
-| Syntactic | AST similarity | Future | Similar code structure |
-| Architectural | Same module = related | Future | Position in system |
-| Social | Same author = related | Skipped | Single-user, not valuable |
-
-**Architecture:** E5-base-v2 (768-dim) → trained MLP (768→1024→256) → USearch HNSW index per dimension.
-
-### Roadmap: Progressive Adapters
-
-The vision: **One engine, variable patina thickness**.
-
-### Patina Thickness Model
-
-Same architecture, progressively richer training data:
-
-- **Fresh patina**: Git + code only (structural understanding)
-- **Working patina**: + sessions (patterns emerging)
-- **Mature patina**: Deep session integration (contextual wisdom)
-
-See `layer/surface/patina-embedding-architecture.md` for full design.
+- **LLM-agnostic**: Adapter pattern for Claude, Gemini, OpenCode
+- **Git as memory**: Sessions and beliefs committed to repo, vectors rebuildable from source
+- **Spec-driven**: Features start as specs, go through lifecycle, trigger releases on completion
 
 ## Requirements
 
-- Rust 1.70+
+- Rust (edition 2021, tested on 1.90+)
 - Git
 - Docker (optional, for `patina yolo` devcontainer generation)
 - `gh` CLI (optional, for `--with-issues` GitHub integration)
@@ -290,13 +298,14 @@ See `layer/surface/patina-embedding-architecture.md` for full design.
 ## Development
 
 ```bash
-# Build release
+# Build and install
 cargo build --release
+cargo install --path .
 
 # Run tests
 cargo test --workspace
 
-# Pre-push checks
+# Pre-push checks (fmt + clippy + tests)
 ./resources/git/pre-push-checks.sh
 ```
 

--- a/layer/core/build.md
+++ b/layer/core/build.md
@@ -1,6 +1,6 @@
 # Build Recipe
 
-**Version:** 0.15.3 — Three pillars: epistemic (complete), mother, distribution.
+**Version:** 0.17.0 — Three pillars: epistemic (complete), mother (architecture shipped), distribution.
 
 ---
 
@@ -10,9 +10,9 @@ A local-first RAG network: portable project knowledge + personal mother.
 
 - **Patina Projects:** `patina init .` - full RAG (semantic, temporal, dependency)
 - **Reference Repos:** `patina repo add <url>` - lightweight index in `~/.patina/cache/repos/`
-- **Mother:** `~/.patina/` - registry, personas, `patina serve` daemon
+- **Mother:** `~/.patina/` - registry, personas, `patina mother start` daemon
 
-**Completed infrastructure:** Scrape pipeline, oxidize embeddings, query/scry, serve daemon, persona, rebuild command, MCP server, hybrid retrieval (MRR 0.624), model management, feedback loop, assay structural queries, spec work-item system (ready queue, auto-release). All working.
+**Completed infrastructure:** Scrape pipeline, oxidize embeddings, query/scry, Mother daemon, persona, rebuild command, MCP server, hybrid retrieval (MRR 0.624), model management, feedback loop, assay structural queries, spec work-item system (ready queue, auto-release), WASM plugin system (WIT component model, command world, doctor extraction), version consolidation, security hardening. All working.
 
 ---
 
@@ -58,7 +58,7 @@ A local-first RAG network: portable project knowledge + personal mother.
 | assay | Query (factual) | Structural signals, FTS5 search, temporal, belief grounding |
 | scry | Query (semantic) | Multi-domain vector similarity — meaning, not keywords |
 
-**Next:** [[mother-architecture]] — children as plugins. Mother is the plugin host (daemon lifecycle, child registry, heartbeat, request routing, toy management). Children are `MotherChild` trait implementors: [[mother-environment]] (models), [[mother-repos]] (ref repos). Native Rust traits now, WIT plugins later via [[patina-platform]].
+**Next:** Mother v2 — cross-project belief index ([[mother-v2]] Phase 2), plugin extraction of more commands via [[patina-platform]]. Mother daemon shipped (lifecycle, child registry, heartbeat, graph routing). WASM plugin system shipped (WIT component model, command world, doctor/models/repos children). Next: federated belief search, environment ownership, grammar plugins.
 
 **Values alignment:**
 - [unix-philosophy](unix-philosophy.md): One tool, one job
@@ -75,9 +75,9 @@ A local-first RAG network: portable project knowledge + personal mother.
 
 | Pillar | Current | Target |
 |--------|---------|--------|
-| **Epistemic** | **COMPLETE** (v0.10.0) — 87 beliefs, verification, grounding, forge | E5/E6 deferred to mother scope |
-| **Mother** | Registry + serve daemon | Federated query, persona fusion |
-| **Distribution** | 52MB fat binary | Slim binary, `patina setup`, Homebrew |
+| **Epistemic** | **COMPLETE** (v0.10.0) — 105 beliefs, verification, grounding, forge | E5/E6 deferred to mother scope |
+| **Mother** | v0.16.0 daemon + v0.17.0 WASM plugins | Federated query, persona fusion, environment ownership |
+| **Distribution** | 66MB binary (16MB wasmtime) | Slim binary, grammar plugins, `patina setup`, Homebrew |
 
 **Milestones:**
 ```
@@ -98,6 +98,10 @@ A local-first RAG network: portable project knowledge + personal mother.
 0.15.0 ✓ Feat: ref repo semantic training (13/13 repos indexed)
 0.15.2 ✓ Refactor: semantic-structural split (scry=meaning, assay=facts, P@10 48.3%)
 0.15.3 ✓ Refactor: spec closure for semantic-structural-split
+0.16.0 ✓ Feat: Mother Architecture (daemon, graph, children, microserver)
+0.16.1 ✓ Refactor: Version Consolidation (ReleaseStrategy, BumpType, auto-release)
+0.16.2 ✓ Refactor: Security Hardening
+0.17.0 ✓ Feat: Plugin System (WASM component model, command world, doctor extraction)
 1.0.0  - All pillars complete
 ```
 

--- a/layer/core/oxidized-knowledge.md
+++ b/layer/core/oxidized-knowledge.md
@@ -2,7 +2,7 @@
 id: oxidized-knowledge
 status: active
 created: 2025-08-11
-updated: 2025-11-21
+updated: 2026-02-12
 references: [session-capture, adapter-pattern]
 tags: [architecture, metaphor, core]
 ---
@@ -19,13 +19,13 @@ Patina distinguishes two types of knowledge:
 
 | Type | Location | Shared? | Contains |
 |------|----------|---------|----------|
-| **Project** | `.patina/` | Yes (git) | Facts about this codebase |
-| **Persona** | `~/.patina/persona/` | No (personal) | Cross-project beliefs |
+| **Project** | `layer/` + `.patina/` | Yes (layer/ in git) | Facts, beliefs, and specs about this codebase |
+| **Persona** | `~/.patina/layer/` | No (personal) | Cross-project beliefs and preferences |
 
 **Project knowledge:** "TypeScript prefers Result types here" - observation about livestore
 **Personal belief:** "I prefer Rust Result<T,E> over exceptions" - your opinion across all projects
 
-Different developers working on the same project share observations but keep separate beliefs.
+Different developers working on the same project share project beliefs but keep separate persona beliefs. Project beliefs live in `layer/surface/epistemic/beliefs/` (git-tracked). Persona beliefs live in `~/.patina/layer/surface/beliefs/` (machine-local).
 
 ## Structure
 
@@ -39,8 +39,11 @@ Different developers working on the same project share observations but keep sep
 - **oxidize.yaml** - recipe for building adapters (git-tracked)
 
 ### Personal (`~/.patina/`)
-- **persona/** - beliefs, preferences, opinions (never shared)
-- **projects.registry** - registered projects on this machine
+- **layer/** - user-level beliefs and preferences (mirror of project layer structure)
+  - `layer/surface/beliefs/` - persona beliefs (machine-local, never shared)
+- **personas/** - legacy event log (being migrated to layer/beliefs)
+- **registry.yaml** - registered projects and repos on this machine
+- **cache/repos/** - cloned reference repositories
 
 ## System
 
@@ -65,7 +68,7 @@ src/**/*               ┘              │
                        ┌────────── vectors
                        │
                        ↓
-~/.patina/persona/ ──→ scry ←── .patina/data/
+~/.patina/layer/   ──→ scry ←── .patina/data/
                        │
                        ↓
               [PROJECT] + [PERSONA] results → LLM context
@@ -100,8 +103,9 @@ src/**/*               ┘              │
 - LLM sees unified context with clear provenance
 
 ### Persona (Personal Only)
-- `/session-note` can capture to persona instead of project
-- `patina persona note "belief"` adds personal belief
+- `patina persona note "belief"` writes to `~/.patina/layer/surface/beliefs/` and legacy event log
+- `patina persona query "topic"` searches persona knowledge
+- `patina persona migrate` converts legacy events to belief files (idempotent)
 - Never synced via git - machine-local only
 - Cross-project: same belief applies to all your work
 

--- a/layer/core/patina-identity.md
+++ b/layer/core/patina-identity.md
@@ -121,15 +121,17 @@ The boundary follows a simple test: **does it serve a core function (capture, in
 | `adapters` | Entry | How users and agents enter Patina. Today: config generators. Future: Mother-managed runtime integration. |
 | `secrets` | Security | Local-first encryption (age + Keychain). Security is core infrastructure that will grow, not optional. |
 
-### Definitely Plugin — extract when plugin system ships
+### Definitely Plugin — extract as plugin system matures
 
-| Module | Lines | Why plugin |
-|--------|-------|------------|
-| `yolo` | 1,613 | Devcontainer generation isn't knowledge. Strongest extraction candidate. |
-| `eval` + `bench` | 3,229 | Quality measurement for power users. Not core to knowledge serving. |
-| `report` | ~400 | Report generation. Composed from core tools — classic plugin. |
-| `doctor` | 278 | Health checks. Useful but not knowledge infrastructure. |
-| `upgrade` | 162 | Version check. Utility, not pillar. |
+`doctor` was the first extraction (v0.17.0) — it ships as a WASM plugin with compiled fallback, proving the pattern works. Next candidates:
+
+| Module | Lines | Why plugin | Status |
+|--------|-------|------------|--------|
+| `yolo` | 1,613 | Devcontainer generation isn't knowledge. Strongest extraction candidate. | Pending |
+| `eval` + `bench` | 3,229 | Quality measurement for power users. Not core to knowledge serving. | Pending |
+| `report` | ~605 | Report generation. Composed from core tools — classic plugin. | Pending |
+| `doctor` | 278 | Health checks. Useful but not knowledge infrastructure. | **Extracted (v0.17.0)** |
+| `upgrade` | 162 | Version check. Utility, not pillar. | Pending |
 
 ## The Plugin Test
 
@@ -153,7 +155,7 @@ If yes → it's a plugin. Forge behavior differs per platform (GitHub vs Gitea v
 
 ### When in doubt: bundle now, extract later
 
-The plugin system doesn't exist yet. Don't architect for extraction prematurely. Build it in, keep the trait boundary clean, and extract when wasmtime ships. The MotherChild trait and existing traits (LLMAdapter, ForgeReader, Oracle) are already the plugin interfaces — they just dispatch to compiled code instead of WASM today.
+The plugin system is live (v0.17.0) — wasmtime + WIT Component Model with two worlds (child world for daemon children, command world for CLI commands). Doctor was the first extraction, proving the pattern: WASM-first with compiled fallback via feature gate (`bundled-doctor`). The MotherChild trait and existing traits (LLMAdapter, ForgeReader, Oracle) are the plugin interfaces — some dispatch to compiled code, some to WASM, with the boundary moving outward over time.
 
 ## Architectural Invariants
 
@@ -223,7 +225,7 @@ Plugin system:  enum dispatch → WIT interface → WASM module
                 Oracle → oracle.wit → oracle-semantic.wasm
 ```
 
-The traits already exist. The WIT interfaces are sketched (see [[wit-interfaces]]). The refactor from enum to trait to WIT is mechanical — one extension point at a time, never a rewrite.
+The traits exist and WIT interfaces are shipping. v0.17.0 delivered two WIT worlds: `child` (daemon children — models, repos) and `command` (CLI commands — doctor). The refactor from enum to trait to WIT is mechanical — one extension point at a time, never a rewrite.
 
 **Key constraint:** wasmtime + WIT Component Model. Not Extism. Separate WIT worlds per plugin type for capability isolation. Two-layer capability grants (manifest + host). See [[patina-platform]].
 

--- a/layer/core/session-capture.md
+++ b/layer/core/session-capture.md
@@ -1,7 +1,7 @@
 ---
 id: session-capture
 status: verified
-verification_date: 2025-08-02
+verification_date: 2026-02-12
 oxidizer: nicabar
 references: [core/session-principles.md, topics/sessions/capture-raw-distill-later.md]
 tags: [sessions, capture, workflow]
@@ -23,20 +23,30 @@ Capture development context with minimal friction:
 
 ## Implementation
 
-```rust
-// Sessions track discovered patterns
-pub struct Session {
-    pub id: String,  // Timestamp-based
-    pub patterns: Vec<SessionPattern>,
-}
+Sessions are YAML-frontmatter markdown files in `layer/sessions/`, managed by `patina session` (CLI) or `/session-*` (adapter slash commands):
 
-// Pattern captured during work
-pub struct SessionPattern {
-    pub name: String,
-    pub pattern_type: String,
-    pub committed: bool,
-}
+```yaml
+---
+type: session
+id: 20260212-161126              # Timestamp-based ID
+title: "feature name"
+status: active                   # active → archived
+llm: claude                      # Which adapter
+created: 2026-02-12T21:11:26Z
+git:
+  branch: patina
+  starting_commit: e1a1736c...
+  start_tag: session-20260212-161126-claude-start
+---
+
+## Previous Session Context
+## Goals
+## Activity Log
+## Beliefs Captured
+## Session Classification
 ```
+
+Git tags bracket each session (`session-{id}-start` / `session-{id}-end`). On end, sessions are classified by work type (feature-work, pattern-work, fix-work, etc.) based on git metrics (files changed, commits, patterns modified).
 
 ## Consequences
 


### PR DESCRIPTION
## Summary
- **README.md**: Full rewrite — was frozen at v0.8.1, now reflects v0.17.0 (27 commands, 61k LOC, WASM plugins, beliefs, MCP, spec lifecycle, secrets, Mother daemon)
- **CLAUDE.md**: Fix project structure (19 modules, not 3), session commands, design philosophy
- **build.md**: Add 4 missing milestones (0.16.0–0.17.0), update version and pillar status
- **patina-identity.md**: Plugin system is shipped, not future — update boundary section and extraction table
- **oxidized-knowledge.md**: Fix persona paths to match reality (~/.patina/layer/), document actual commands
- **session-capture.md**: Replace fictional Rust structs with actual YAML-frontmatter session format

## Test plan
- [ ] Docs only — no code changes, no behavioral impact
- [ ] All pre-push checks pass (fmt, clippy, 165 tests)