### PR TITLE
fix: post-filter-repo cleanup + pre-commit large file guard

### DIFF
--- a/layer/sessions/20260306-171859.md
+++ b/layer/sessions/20260306-171859.md
@@ -31,13 +31,13 @@ Tagged as: session-20260306-171859-claude-start
 Read all required materials: 4 values, pipe-architecture SPEC.md + DESIGN.md, core-extraction + mother-maturation container patterns, session 9+10 notes, forge plugin code (plugin.toml, lib.rs, github.rs), host_support.rs, MCP server pattern, secrets module, CLI help, all 6 specs needing blocker cleanup.
 
 ### 17:40 - Child Specs Created
-[[commit-40f17af4]] — Created 5 child specs via `patina spec create`, set metadata (related, beliefs, blocked_by), wrote full SPEC.md for each: pipe-protocol-types, pipe-native-transport, github-connector, patina-connect, mother-broker. Each has context, exit criteria, steps, key files, and non-goals.
+[[commit-a38739c3]] — Created 5 child specs via `patina spec create`, set metadata (related, beliefs, blocked_by), wrote full SPEC.md for each: pipe-protocol-types, pipe-native-transport, github-connector, patina-connect, mother-broker. Each has context, exit criteria, steps, key files, and non-goals.
 
 ### 17:45 - Container Restructure Complete
-[[commit-0b95a3aa]] — Replaced 6 exit criteria + 10 steps with single container exit criterion and Children table with dependency graph. Architecture content preserved as reference bible.
+[[commit-cfcb50a7]] — Replaced 6 exit criteria + 10 steps with single container exit criterion and Children table with dependency graph. Architecture content preserved as reference bible.
 
 ### 17:50 - Stale Blocker Cleanup Complete
-[[commit-31231aa6]] — Fixed 6 specs:
+[[commit-e6e57169]] — Fixed 6 specs:
 - continuous-operation: removed complete data-architecture-v3 blocker
 - persona-federation: removed stale plugin-infrastructure blocker
 - mother-maturation: removed stale plugin-infrastructure blocker
@@ -51,7 +51,7 @@ Read all required materials: 4 values, pipe-architecture SPEC.md + DESIGN.md, co
 - Dependency graph: [[spec-pipe-protocol-types]] → [[spec-pipe-native-transport]] → [[spec-github-connector]] → [[spec-mother-broker]] (+ [[spec-patina-connect]] parallel)
 
 ### 18:10 - Review-Driven Clarifications
-[[commit-02243a52]] — Addressed external review feedback on 4 child specs:
+[[commit-f3de3662]] — Addressed external review feedback on 4 child specs:
 - [[spec-pipe-protocol-types]]: clarified child.toml vs plugin.toml as separate formats (not migration), canonical serialization scope (JSON-only, test fixtures), design reference pointer to parent DESIGN.md
 - [[spec-pipe-native-transport]]: expanded sandbox EC to include Linux Landlock stub, scoped step 7 spawn logic as minimal test-only (production lifecycle is [[spec-mother-broker]])
 - [[spec-github-connector]]: clarified credential source independence (manual PAT works via `patina secrets add`, no dependency on [[spec-patina-connect]]), added parity verification step before forge deletion

--- a/layer/sessions/20260306-204943.md
+++ b/layer/sessions/20260306-204943.md
@@ -47,7 +47,7 @@ Design for `src/connect/` module: OAuth device flow (RFC 8628) step-by-step impl
 Design for `src/broker/` module: sources.toml format spec (connection, params, types, schedule fields), sources reader with scan_all_sources() across registered projects, BrokerChild trait (unified over WASM and native — fetch with on_fact callback, health, shutdown), NativeChild implementation (interleaved notification/response reading), WasmBrokerChild adapter (wraps existing MotherChild, facts bypass broker routing via host_emit), native child spawn (resolve binary from ~/.patina/children/ or PATH or target/release/, sandbox profile generation, pipe/initialize handshake, credential delivery), fact routing (validate_fact extracts pattern from host_support::validate_emit, content_hash verification, dedup via data string comparison), transactional cursor management (write_facts_with_cursor in single SQLite transaction), broker public API (run_source orchestrating full flow, status showing all sources), CLI wiring (patina mother run/sources), on-scrape scheduling trigger, explicit no-fan-out-optimization decision. 8 commits planned. 3 open questions: events.db per-project path, schema loading scope, WASM fact routing bypass.
 
 ### 22:00 - All 5 DESIGN.md Files Committed
-Committed [[commit-1159c660]]: 3,952 lines of design across all 5 pipe-architecture child specs. Total: 30 planned commits across 5 implementation sessions.
+Committed [[commit-3e1ae36c]]: 3,952 lines of design across all 5 pipe-architecture child specs. Total: 30 planned commits across 5 implementation sessions.
 
 
 ## Beliefs Captured: 0

--- a/layer/sessions/20260306-212545.md
+++ b/layer/sessions/20260306-212545.md
@@ -33,7 +33,7 @@ Tagged as: session-20260306-212545-claude-start
 Compared established DESIGN.md patterns (e.g., [[spec-core-extraction]]) against the 5 new pipe-architecture child files. Found systematic quality gap: files were implementation guides (~70% code), not design documents. Missing: "Why This Work Exists" narrative, `[[belief]]` anchors, session citations, concept-driven structure, "What's NOT In Scope" sections, belief anchors. Root cause: Session 13 wrote all 5 in 70 minutes — grounding was thorough but writing prioritized completeness over reasoning.
 
 ### 22:00 - Rewrite All 5 Child DESIGN.md Files
-[[commit-fa597aea]] — Rewrote all 5 files with design-first framing:
+[[commit-984f6636]] — Rewrote all 5 files with design-first framing:
 - [[spec-pipe-protocol-types]] DESIGN.md: "The Type Unification Problem", 6 numbered design decisions (PipeError codes as transport detail per [[session-20260306-174214]], zeroize boundary, opaque cursors, canonical JSON trade-off)
 - [[spec-pipe-native-transport]] DESIGN.md: "Why Children Should Be Processes", anchored in [[pipes-are-processes-not-wasm]], streaming delivery, sandbox-must-fail-loud constraint
 - [[spec-github-connector]] DESIGN.md: "Proving the Native Child Pattern", migration table, HTTP error mapping, parity verification plan, deletion checklist
@@ -50,11 +50,11 @@ Found 6 contradictions between parent [[spec-pipe-architecture]] DESIGN.md (writ
 5. Signing presented as current, actually stubbed
 6. Persona enforcement presented as initial scope, actually future
 Also: `pipe/emit` and `pipe/capabilities` methods not in any child — marked as future.
-[[commit-f1f38af8]] — Fixed all 6 + abandoned [[spec-forge-plugin-extraction]] (superseded by [[spec-github-connector]] and [[spec-mother-broker]]).
+[[commit-15c75ffa]] — Fixed all 6 + abandoned [[spec-forge-plugin-extraction]] (superseded by [[spec-github-connector]] and [[spec-mother-broker]]).
 
 ### 22:25 - File Location Fix
 Discovered [[spec-github-connector]] and [[spec-patina-connect]] DESIGN.md files were in `refactor/` but their SPEC.md lives in `feat/` (they're feature specs, not refactors). Session 13 wrote them to the wrong directory.
-[[commit-ec85c2ee]] — Moved DESIGN.md files to `feat/` directories, removed orphaned `refactor/` directories.
+[[commit-89d8b95c]] — Moved DESIGN.md files to `feat/` directories, removed orphaned `refactor/` directories.
 
 ### 22:35 - External Audit Response
 Addressed external cross-spec audit with 10 findings. 4 genuine gaps fixed, 3 already addressed in DESIGN.md, 3 not actionable:
@@ -62,7 +62,7 @@ Addressed external cross-spec audit with 10 findings. 4 genuine gaps fixed, 3 al
 2. **Fixed:** [[spec-pipe-protocol-types]] SDK rename atomicity — commits 4-5 must ship together or forge breaks.
 3. **Fixed:** [[spec-pipe-architecture]] parent — added Schema Resolution §4.5 unifying schema ownership across three specs (manifest declares, schema.toml defines, broker validates).
 4. **Fixed:** [[spec-mother-broker]] — added Sandbox Failure Surfacing section (how OS sandbox blocks appear in CLI output).
-[[commit-0f68499f]]
+[[commit-b8c3f06a]]
 
 ### 22:50 - Next Session Prompt
 Wrote self-contained prompt for next session: audit walkthrough + narrative alignment. Three phases: (1) ground in core values + read all specs + read referenced code, (2) walk through each spec with user, (3) write clean feature narrative. Fits in single 150k session (~7,200 lines of reading).

--- a/layer/sessions/20260307-061822.md
+++ b/layer/sessions/20260307-061822.md
@@ -55,7 +55,7 @@ Discussed each security item with user rather than deferring:
 Wrote "What Pipe Architecture Solves" as new opening section of parent DESIGN.md (~165 lines). Covers: problem statement, user experience (before/after with concrete commands), protocol/children/broker explanation, five specs summary, build order, and exists-today-vs-new comparison table. Three user-requested tweaks: cursor idempotency, Mother as single enforcement point, sandbox hard-fail posture in build order.
 
 ### 07:30 - Commit 1
-[[commit-22b21f77]] — audit walkthrough, narrative, and security posture for pipe-architecture. 10 files, +415/-67 lines.
+[[commit-63a15297]] — audit walkthrough, narrative, and security posture for pipe-architecture. 10 files, +415/-67 lines.
 
 ### 07:40 - Verification Walkthrough
 Ran two parallel verification agents:
@@ -69,7 +69,7 @@ Ran two parallel verification agents:
 - Narrative listed `pipe/fact` alongside methods — clarified it's a streaming notification
 
 ### 07:50 - Commit 2
-[[commit-7949d1cf]] — fix sandbox terminology drift and build-order diagram. 4 files, +25/-23 lines.
+[[commit-39e0100b]] — fix sandbox terminology drift and build-order diagram. 4 files, +25/-23 lines.
 
 ### 07:55 - Final Verification
 All categories pass: blocked_by consistency, EC ownership, trait signatures, sandbox references, build order, resolved questions, cross-references, narrative claims. Two accepted WARNs: redundant integration EC across github-connector and mother-broker, cosmetic reference format inconsistency.

--- a/layer/sessions/20260307-071440.md
+++ b/layer/sessions/20260307-071440.md
@@ -53,10 +53,10 @@ Standardized [[spec-pipe-architecture]] children table from bare `[[pipe-protoco
 Parallel verification agent confirmed 7/7 tasks pass. All criteria met.
 
 ### 07:55 - Commits (surgical staging)
-- [[commit-abedf469]] — session: archive session 20260307-061822 (audit walkthrough)
-- [[commit-9b904c10]] — spec: add verification artifacts to all pipe-architecture ECs
-- [[commit-5549f4fd]] — spec: standardize wikilink format in pipe-architecture children table
-- [[commit-a5fa2960]] — spec: add cross-links, test matrix, and risk log to pipe-architecture
+- [[commit-2800b911]] — session: archive session 20260307-061822 (audit walkthrough)
+- [[commit-5802800d]] — spec: add verification artifacts to all pipe-architecture ECs
+- [[commit-e7cb45db]] — spec: standardize wikilink format in pipe-architecture children table
+- [[commit-1af3aa3a]] — spec: add cross-links, test matrix, and risk log to pipe-architecture
 
 ### 08:00 - Next Session Prompt
 Wrote implementation prompt for [[spec-pipe-protocol-types]] — the foundation crate. Identified SDK structure risk: host_* modules are inline `pub mod` blocks via wit_bindgen::generate!, not separate files. blake3 not in dep tree (sha2 is via age).

--- a/layer/sessions/20260307-073227.md
+++ b/layer/sessions/20260307-073227.md
@@ -37,13 +37,13 @@ Read all required source files (~1,500 lines): `src/plugin/internal/host_support
 Confirmed blake3 NOT in dep tree (`cargo tree | grep blake3` — empty). sha2 IS (via age). Decision: add blake3 per architecture spec. Confirmed SDK uses inline `pub mod` blocks, NOT separate files. `query`, `layer`, `measure` already use short names — only `host_log`, `host_http`, `host_emit` need rename. `crates/` directory does not exist yet.
 
 ### 07:42 - Commit 1: pipe-types crate
-Created `crates/patina-pipe-types/` with all 7 source files: `lib.rs`, `fact.rs` (Fact, FetchResult), `error.rs` (PipeError with Display + Error), `capabilities.rs` (Capabilities, Status, HealthStatus), `config.rs` (InitializeParams, AuthConfig, FetchParams), `canonical.rs` (recursive sorted-key serializer + blake3 content_hash), `manifest.rs` (ChildManifest with ChildType/Runtime/Lifecycle enums). 19 tests (12 canonical/hash fixtures, 7 manifest parse/round-trip). Added to workspace members. [[commit-7698fc8e]]
+Created `crates/patina-pipe-types/` with all 7 source files: `lib.rs`, `fact.rs` (Fact, FetchResult), `error.rs` (PipeError with Display + Error), `capabilities.rs` (Capabilities, Status, HealthStatus), `config.rs` (InitializeParams, AuthConfig, FetchParams), `canonical.rs` (recursive sorted-key serializer + blake3 content_hash), `manifest.rs` (ChildManifest with ChildType/Runtime/Lifecycle enums). 19 tests (12 canonical/hash fixtures, 7 manifest parse/round-trip). Added to workspace members. [[commit-a12e3386]]
 
 ### 07:50 - Commit 2: SDK rename
-Renamed `host_log→log` in all 4 world files (mother_child.rs, task.rs, command.rs, pipeline.rs), `host_http→fetch` in mother_child.rs + task.rs, `host_emit→emit` in mother_child.rs. [[commit-d0fd66b4]]
+Renamed `host_log→log` in all 4 world files (mother_child.rs, task.rs, command.rs, pipeline.rs), `host_http→fetch` in mother_child.rs + task.rs, `host_emit→emit` in mother_child.rs. [[commit-71d986a4]]
 
 ### 07:52 - Commit 3: Plugin import updates
-Updated forge (lib.rs + github.rs) and repos (lib.rs) to use new SDK module names. Updated doc comments. `cargo build --release` confirms entire workspace compiles. [[commit-3646dfa4]] (amended with `cargo fmt` fix)
+Updated forge (lib.rs + github.rs) and repos (lib.rs) to use new SDK module names. Updated doc comments. `cargo build --release` confirms entire workspace compiles. [[commit-3ccce511]] (amended with `cargo fmt` fix)
 
 ### 07:55 - EC Verification
 - **pipe-types-crate-compiles**: 19/19 tests pass, cross-runtime hash fixtures produce identical values
@@ -54,7 +54,7 @@ Updated forge (lib.rs + github.rs) and repos (lib.rs) to use new SDK module name
 Compared spec vs reality. Found 4 divergences: (1) SDK missing pipe-types dependency/re-export — real gap. (2) `host_query→query` was a no-op (already named `query`). (3) 3 commits instead of 5 — acceptable, workspace buildable at each step. (4) PipeError jsonrpc methods omitted — matches design decision "types crate knows nothing about transport."
 
 ### 08:02 - Commit 4: SDK pipe-types dependency
-Added `patina-pipe-types` as dependency of `patina-sdk`, re-exported as `patina_sdk::pipe_types`. Resolves divergence #1. [[commit-f79b81de]]
+Added `patina-pipe-types` as dependency of `patina-sdk`, re-exported as `patina_sdk::pipe_types`. Resolves divergence #1. [[commit-2ae24270]]
 
 ### 08:05 - Pre-Push Checks
 All 6 checks pass: WIT consistency, WIT symlinks, formatting, clippy, tests, MCP handler invariants.

--- a/layer/sessions/20260307-075156.md
+++ b/layer/sessions/20260307-075156.md
@@ -37,25 +37,25 @@ Read all required files: src/mcp/protocol.rs (52 lines, JSON-RPC types), src/mcp
 No landlock in dep tree. No sandbox_init usage in src/. pipe-types deps: serde, serde_json, blake3, toml.
 
 ### 08:02 - Commit 1: protocol types + FactEmitter
-Created crates/patina-pipe/ with Cargo.toml, protocol.rs (Request/Response/Notification following MCP pattern), emitter.rs (streaming FactEmitter with auto content hashing). 7 tests. [[commit-6fce4c5c]]
+Created crates/patina-pipe/ with Cargo.toml, protocol.rs (Request/Response/Notification following MCP pattern), emitter.rs (streaming FactEmitter with auto content hashing). 7 tests. [[commit-a9709590]]
 
 ### 08:08 - Commit 2: Child trait + run() dispatcher
-Full Child trait (capabilities, initialize, fetch with FactEmitter, health). run() function: BufReader stdin, line-delimited JSON-RPC, all error paths explicit per DESIGN.md §3. PipeError → JSON-RPC code mapping (-32001..-32004). 14 tests. [[commit-a3fad9ab]]
+Full Child trait (capabilities, initialize, fetch with FactEmitter, health). run() function: BufReader stdin, line-delimited JSON-RPC, all error paths explicit per DESIGN.md §3. PipeError → JSON-RPC code mapping (-32001..-32004). 14 tests. [[commit-58c4b46f]]
 
 ### 08:12 - Commit 3: test-child example
-Minimal Child impl with fake GitHub data (2 issues, 1 PR). End-to-end verified: pipe/initialize → pipe/fetch with 3 streaming notifications → pipe/health → pipe/shutdown. [[commit-ab988948]]
+Minimal Child impl with fake GitHub data (2 issues, 1 PR). End-to-end verified: pipe/initialize → pipe/fetch with 3 streaming notifications → pipe/health → pipe/shutdown. [[commit-7e6b8260]]
 
 ### 08:15 - Commit 4: macOS sandbox
-Thin FFI for sandbox_init() C API (~50 lines). SBPL profile generator with domain regex injection. cfg(target_os = "macos"). 3 profile tests. [[commit-8cf6976e]]
+Thin FFI for sandbox_init() C API (~50 lines). SBPL profile generator with domain regex injection. cfg(target_os = "macos"). 3 profile tests. [[commit-0c4ba951]]
 
 ### 08:18 - Commit 5: Linux Landlock
-Landlock ABI v4+ enforcement. Deny all filesystem, allow port 443 + 53. check_landlock_support() for kernel detection. cfg(target_os = "linux") gated. [[commit-7a53a1a2]]
+Landlock ABI v4+ enforcement. Deny all filesystem, allow port 443 + 53. check_landlock_support() for kernel detection. cfg(target_os = "linux") gated. [[commit-c0dfc6d6]]
 
 ### 08:22 - Commit 6: Mother-side test harness
-spawn_child() + ChildConnection for integration testing. Full end-to-end test: spawn test-child, initialize, fetch with 3 fact notifications (verified blake3 hashes), health, shutdown. [[commit-54e429ba]]
+spawn_child() + ChildConnection for integration testing. Full end-to-end test: spawn test-child, initialize, fetch with 3 fact notifications (verified blake3 hashes), health, shutdown. [[commit-3edf6c3d]]
 
 ### 08:25 - Clippy fix + pre-push checks
-Fixed drop_non_drop clippy lint by scoping emitter in a block. All 6 pre-push checks pass. [[commit-eeae6792]]
+Fixed drop_non_drop clippy lint by scoping emitter in a block. All 6 pre-push checks pass. [[commit-841691a0]]
 
 ### 08:30 - Divergence Audit
 5 acceptable divergences (naming, improvements, commit boundaries), 1 real gap: EC3 sandbox enforcement not testable from this crate alone — requires Mother-side spawn integration in [[spec-mother-broker]]. User confirmed gap is correctly scoped.
@@ -64,13 +64,13 @@ Fixed drop_non_drop clippy lint by scoping emitter in a block. All 6 pre-push ch
 Audited all `cfg(target_os)` and `cfg(unix)` code across codebase. Found: 14 `cfg(unix)` blocks (tested both platforms), 13 `cfg(target_os = "macos")` blocks (local only), 4 `cfg(target_os = "linux")` blocks (CI only, no runtime tests). Key gaps: Keychain (~200 lines macOS-only, no CI), Landlock (new code, never executed), machine-id (Linux-only path).
 
 ### 08:50 - Docker Linux Test Infrastructure
-Created `scripts/test-linux.sh` — Docker wrapper using `rust:1.90.0` image, named cargo cache volume, separate CARGO_TARGET_DIR. Split sandbox tests: `macos_tests` (cfg macOS), `linux_tests` (cfg Linux). [[commit-47f20636]]
+Created `scripts/test-linux.sh` — Docker wrapper using `rust:1.90.0` image, named cargo cache volume, separate CARGO_TARGET_DIR. Split sandbox tests: `macos_tests` (cfg macOS), `linux_tests` (cfg Linux). [[commit-6d683c6d]]
 
 ### 09:00 - Landlock API Bugs Found via Docker
 First Docker run caught 3 real bugs: wrong `NetPort` constructor (needs 2 args), private `RulesetCreated::new()`, missing `libc` dependency. These compiled fine on macOS (cfg-gated, never ran) — exactly the scenario we predicted.
 
 ### 09:10 - Landlock Enforcement Verified
-Fork-based test: child applies Landlock irrevocably, verifies port 80 blocked (EPERM) and port 443 allowed. Kernel 6.12 via Docker Desktop. Fixed script exit code propagation. [[commit-d3240685]]
+Fork-based test: child applies Landlock irrevocably, verifies port 80 blocked (EPERM) and port 443 allowed. Kernel 6.12 via Docker Desktop. Fixed script exit code propagation. [[commit-4a324cd7]]
 
 ### 09:15 - Shortcuts Identified
 8 gaps documented: (1) macOS apply_sandbox() never tested, (2) Landlock test depends on external network (1.1.1.1), (3) check_landlock_support() hardcodes ABI v4, (4) --no-sandbox flag doesn't exist, (5) machine-id Linux gap, (6) Docker doesn't cache toolchain, (7) Docker only works for patina-pipe, (8) EC3 spawn→sandbox→exec untested.

--- a/layer/sessions/20260307-092539.md
+++ b/layer/sessions/20260307-092539.md
@@ -31,19 +31,19 @@ Tagged as: session-20260307-092539-claude-start
 ### 12:44 - Update (covering since 09:25)
 
 **Git Activity:**
-- Commits this session: 7 ([[commit-be7399a1]], [[commit-d2167a33]], [[commit-b5c527c5]], [[commit-bc1a343c]], [[commit-385c94c6]], [[commit-88530c23]], [[commit-c4bfcde9]])
+- Commits this session: 7 ([[commit-1f76c359]], [[commit-399a6bb2]], [[commit-7f1cd08b]], [[commit-4489aa54]], [[commit-d60ae780]], [[commit-e1b9a7e8]], [[commit-158d55b1]])
 - Files changed: 10 across 3 crates + 3 specs
 - Specs changed: [[spec-pipe-native-transport]], [[spec-pipe-architecture]], [[spec-pipe-mother-io]] (new)
 
 **Work completed:**
 - All 8 testing gaps from previous session addressed
-- Found 2 real bugs in macOS `apply_sandbox()`: wrong `sandbox_init()` flag (0x0003→0x0000, treated profile as file path not inline SBPL), invalid SBPL syntax (`remote port` → `remote ip`) [[commit-c4bfcde9]]
-- Fixed Landlock ABI detection: `SoftRequirement` → `HardRequirement` so probe actually detects v4 support [[commit-88530c23]]
-- Replaced external network dependency (1.1.1.1) in Landlock test with loopback (EACCES vs ECONNREFUSED) [[commit-88530c23]]
-- Added macOS fork-based enforcement test: sandbox_init(), verify /etc/passwd blocked, /dev/null allowed [[commit-c4bfcde9]]
-- Added `#[cfg(target_os = "linux")]` test for `read_machine_id_file()` in `src/secrets/encrypted_file.rs` [[commit-385c94c6]]
-- Docker script: default scope changed to `-p patina-pipe`, added target dir cache volume [[commit-385c94c6]]
-- Documented EC3 spawn→sandbox→exec as [[spec-mother-broker]] scope in `harness.rs` [[commit-385c94c6]]
+- Found 2 real bugs in macOS `apply_sandbox()`: wrong `sandbox_init()` flag (0x0003→0x0000, treated profile as file path not inline SBPL), invalid SBPL syntax (`remote port` → `remote ip`) [[commit-158d55b1]]
+- Fixed Landlock ABI detection: `SoftRequirement` → `HardRequirement` so probe actually detects v4 support [[commit-e1b9a7e8]]
+- Replaced external network dependency (1.1.1.1) in Landlock test with loopback (EACCES vs ECONNREFUSED) [[commit-e1b9a7e8]]
+- Added macOS fork-based enforcement test: sandbox_init(), verify /etc/passwd blocked, /dev/null allowed [[commit-158d55b1]]
+- Added `#[cfg(target_os = "linux")]` test for `read_machine_id_file()` in `src/secrets/encrypted_file.rs` [[commit-d60ae780]]
+- Docker script: default scope changed to `-p patina-pipe`, added target dir cache volume [[commit-d60ae780]]
+- Documented EC3 spawn→sandbox→exec as [[spec-mother-broker]] scope in `harness.rs` [[commit-d60ae780]]
 
 **Key decisions:**
 - Discovered OS sandboxes (SBPL, Landlock) cannot filter by hostname — only port/IP. The manifest `domains` field was unenforced. This is not "future work" — it's a security gap.

--- a/layer/sessions/20260307-125108.md
+++ b/layer/sessions/20260307-125108.md
@@ -30,31 +30,31 @@ Tagged as: session-20260307-125108-claude-start
 ### 14:32 - Update (covering since 12:51)
 
 **Git Activity:**
-- Commits this session: 8 ([[commit-cd73e0b4]], [[commit-f14a5f73]], [[commit-baf36c02]], [[commit-ec3559c8]], [[commit-ebc81ef4]], [[commit-2c98b523]], [[commit-bfc288b1]], [[commit-ec37ef56]])
+- Commits this session: 8 ([[commit-4e2502b1]], [[commit-49ec960a]], [[commit-de45d917]], [[commit-2f20f807]], [[commit-e40329bf]], [[commit-d074a9d8]], [[commit-03327c8b]], [[commit-46f70a7d]])
 - Files changed: 13 across 2 crates + 3 specs
 - Specs changed: [[spec-pipe-mother-io]], [[spec-pipe-native-transport]], [[spec-mother-broker]]
 
 **Work completed:**
-- **EC1: pipe/http protocol + Mother handler** [[commit-ec37ef56]]
+- **EC1: pipe/http protocol + Mother handler** [[commit-46f70a7d]]
   - `PipeHttpRequest`/`PipeHttpResponse` types in `crates/patina-pipe-types/src/http.rs`
   - `PipeIo` context in `crates/patina-pipe/src/pipe_io.rs` — replaces `FactEmitter` as Child::fetch() parameter, combines fact emission with HTTP builder pattern (`io.get(url).header(k,v).send()`)
   - `ChildConnection` in `crates/patina-pipe/src/harness.rs` handles `pipe/http` requests from children via `HttpHandler` callback — patina-pipe doesn't depend on reqwest
   - `run()` refactored from `reader.lines()` to `read_line()` loop so BufReader is shareable with PipeIo during fetch
-- **EC2: Sandbox tightening** [[commit-bfc288b1]]
+- **EC2: Sandbox tightening** [[commit-03327c8b]]
   - macOS: removed `network-outbound` and `system-socket` rules — deny-all network
   - Linux: removed `NetPort` 443/53 `add_rule` calls — Landlock denies all TCP
   - Tests verify ALL ports get blocked including 443
   - Docker Linux tests pass: `./scripts/test-linux.sh -p patina-pipe` — 22 tests green
-- **EC3: PipeIo helper** (part of [[commit-ec37ef56]])
+- **EC3: PipeIo helper** (part of [[commit-46f70a7d]])
   - `PipeIo` provides `get()/post()/put()/patch()/delete()` with `HttpRequestBuilder` (header, body, send)
   - `examples/test-http-child.rs` uses the helper with zero reqwest references
-- **Integration test** [[commit-2c98b523]]
+- **Integration test** [[commit-d074a9d8]]
   - `test-http-child` makes pipe/http requests to allowed and denied domains
   - Mock handler enforces domain allowlist: `api.allowed.com` → 200, `evil.com` → rejected
-- **EC4: Audit logging** [[commit-baf36c02]]
+- **EC4: Audit logging** [[commit-de45d917]]
   - stderr audit log: method, URL, decision (status/DENIED), duration, bytes
   - Full Measure→eventlog emission blocked on mother-broker
-- Activated [[spec-mother-broker]] (draft → ready → active) [[commit-cd73e0b4]]
+- Activated [[spec-mother-broker]] (draft → ready → active) [[commit-4e2502b1]]
 
 **Key decisions:**
 - Named it `PipeIo` not `MotherHttpClient` — combines fact emission AND HTTP in one context. Better name since fetch() needs both capabilities, not just HTTP

--- a/layer/sessions/20260307-143548.md
+++ b/layer/sessions/20260307-143548.md
@@ -66,7 +66,7 @@ Tagged as: session-20260307-143548-claude-start
 ### 15:18 - Update (covering since 14:43)
 
 **Git Activity:**
-- Commits this session: 3 ([[commit-3ea764cd]], [[commit-9356d602]], [[commit-19807efb]])
+- Commits this session: 3 ([[commit-df0988aa]], [[commit-25000fba]], [[commit-19961422]])
 - Files changed: 2 (`DESIGN.md`, `SPEC.md`)
 - Last commit: 2 minutes ago
 
@@ -79,12 +79,12 @@ Tagged as: session-20260307-143548-claude-start
   - §12: Made HTTP client construction fallible, added domain normalization (lowercase, port-stripped)
   - §13: Added `max_batch_size` limit (10k default), documented v2 streaming path
 - Phase 4 (Alignment Audit): mapped all 9 SPEC.md ECs to DESIGN.md decisions. Found 3 mismatches + 2 gaps:
-  - Schema validation: added §6 decision table (undeclared = drop, uninstalled = warn + pass-through) [[commit-9356d602]]
+  - Schema validation: added §6 decision table (undeclared = drop, uninstalled = warn + pass-through) [[commit-25000fba]]
   - Credentials EC: rewritten to cover Tier 1 (header injection) and Tier 2 (pipe/initialize token)
   - `source_id` format: `child:{child_name}` documented in §6
   - Sandbox enforcement: new section — default sandbox-on, `--no-sandbox` override, failure surfacing
   - Mother status: new section — broker_cursors + WriteResult + eventlog feeding status output
-- Scope narrowing: removed 4 SPEC.md contradictions [[commit-3ea764cd]]:
+- Scope narrowing: removed 4 SPEC.md contradictions [[commit-df0988aa]]:
   - Scheduling: v1 = manual + on-scrape only (stream/hourly/daily → [[spec-continuous-operation]])
   - Fan-out: removed shared-spawn promise, v1 = one spawn per source + content-hash dedup
   - Uniform lifecycle: EC `mother-spawns-children` now accurately describes WASM legacy path

--- a/layer/sessions/20260307-152310.md
+++ b/layer/sessions/20260307-152310.md
@@ -28,23 +28,23 @@ Tagged as: session-20260307-152310-claude-start
 ### 15:59 - Update (covering since 15:23)
 
 **Git Activity:**
-- Commits this session: 12 ([[commit-d0cd26e9]], [[commit-6c7fa105]], [[commit-dc876241]], [[commit-ba76474d]], [[commit-95acec6d]], [[commit-69d66edc]], [[commit-60d45f9a]], [[commit-de2696fa]], [[commit-26ff41b8]], [[commit-203fdf98]], [[commit-c20bded7]], [[commit-a99133ac]])
+- Commits this session: 12 ([[commit-d954bd57]], [[commit-b3818319]], [[commit-882e8cde]], [[commit-ee876859]], [[commit-121f8613]], [[commit-e288005d]], [[commit-cdfad382]], [[commit-1fda7a51]], [[commit-cf511c21]], [[commit-74712190]], [[commit-0f4f9e4f]], [[commit-8c8ddeff]])
 - Files changed: 18 (8 new broker modules, 5 modified existing files, Cargo.toml/lock)
 - Last commit: 17 minutes ago
 
 **Work completed — full 11-commit plan executed:**
-- #1 [[commit-d0cd26e9]]: `eventlog.rs` — `content_hash TEXT` column with partial UNIQUE index, `broker_cursors` table, `open_events_db_at()` for per-project writes
-- #2 [[commit-6c7fa105]]: `broker/connection.rs` — `ConnectionConfig`, `load_connection()`, schema_version validation (§8)
-- #3 [[commit-dc876241]]: `broker/sources.rs` — `SourceEntry`, `ProjectSources`, `scan_all_sources()`, `find_source()`
-- #4 [[commit-ba76474d]]: `broker/lifecycle.rs` — `BrokerChild` trait, `NativeChild` adapter wrapping `ChildConnection`, `max_batch_size` enforcement, error attribution tracing
-- #5 [[commit-95acec6d]]: `broker/http.rs` — `build_production_handler()`, host_support functions changed to `pub(crate)`, domain normalization (lowercase, port-stripped)
-- #6 [[commit-69d66edc]]: `broker/spawn.rs` — `spawn_native()`, `resolve_child_binary()` (3-path search), credential delivery tiers (§9), sandbox enforcement
-- #7 [[commit-60d45f9a]]: `broker/routing.rs` — `validate_fact()` with §6 decision table, `write_facts()` with INSERT OR IGNORE dedup, `WriteResult`
-- #8 [[commit-de2696fa]]: `broker/cursor.rs` — `write_facts_with_cursor()` wrapping facts + cursor in single `unchecked_transaction()`
-- #9 [[commit-26ff41b8]]: `broker/mod.rs` — `run_source()` orchestrating full flow, `status()` reading broker_cursors + eventlog
-- #10 [[commit-203fdf98]]: `commands/mother/mod.rs` — `patina mother run <name>` and `patina mother sources` CLI commands with `--prune`
-- #11 [[commit-c20bded7]]: `commands/scrape/mod.rs` — `trigger_on_scrape_sources()` after local scrape
-- #12 [[commit-a99133ac]]: `cargo fmt --all` formatting
+- #1 [[commit-d954bd57]]: `eventlog.rs` — `content_hash TEXT` column with partial UNIQUE index, `broker_cursors` table, `open_events_db_at()` for per-project writes
+- #2 [[commit-b3818319]]: `broker/connection.rs` — `ConnectionConfig`, `load_connection()`, schema_version validation (§8)
+- #3 [[commit-882e8cde]]: `broker/sources.rs` — `SourceEntry`, `ProjectSources`, `scan_all_sources()`, `find_source()`
+- #4 [[commit-ee876859]]: `broker/lifecycle.rs` — `BrokerChild` trait, `NativeChild` adapter wrapping `ChildConnection`, `max_batch_size` enforcement, error attribution tracing
+- #5 [[commit-121f8613]]: `broker/http.rs` — `build_production_handler()`, host_support functions changed to `pub(crate)`, domain normalization (lowercase, port-stripped)
+- #6 [[commit-e288005d]]: `broker/spawn.rs` — `spawn_native()`, `resolve_child_binary()` (3-path search), credential delivery tiers (§9), sandbox enforcement
+- #7 [[commit-cdfad382]]: `broker/routing.rs` — `validate_fact()` with §6 decision table, `write_facts()` with INSERT OR IGNORE dedup, `WriteResult`
+- #8 [[commit-1fda7a51]]: `broker/cursor.rs` — `write_facts_with_cursor()` wrapping facts + cursor in single `unchecked_transaction()`
+- #9 [[commit-cf511c21]]: `broker/mod.rs` — `run_source()` orchestrating full flow, `status()` reading broker_cursors + eventlog
+- #10 [[commit-74712190]]: `commands/mother/mod.rs` — `patina mother run <name>` and `patina mother sources` CLI commands with `--prune`
+- #11 [[commit-0f4f9e4f]]: `commands/scrape/mod.rs` — `trigger_on_scrape_sources()` after local scrape
+- #12 [[commit-8c8ddeff]]: `cargo fmt --all` formatting
 
 **Key decisions:**
 - Added `patina-pipe` and `patina-pipe-types` as workspace dependencies of `patina-ai` (broker needs `ChildConnection` and `HttpHandler`)

--- a/layer/sessions/20260307-165002.md
+++ b/layer/sessions/20260307-165002.md
@@ -45,7 +45,7 @@ Phase 1 — Test infrastructure wired:
 - Created `.patina/sources.toml` with test source
 - Added test credential to global vault (`patina secrets add --global`)
 
-Phase 2 — Bugs found and fixed ([[commit-bfa9df69]]):
+Phase 2 — Bugs found and fixed ([[commit-85989a3f]]):
 - `FetchParams::to_json()` omitted `types` and `limit` (required by pipe protocol) — pipe_types::FetchParams needs both, broker made them optional
 - `build_init_params()` missing `provider` in auth section — `AuthConfig` requires `{token, provider}`, broker only sent `{token}`
 - Root cause: [[cross-crate-json-contracts-need-shared-types]] — ad-hoc JSON maps drift from struct definitions
@@ -54,10 +54,10 @@ Phase 3 — EC verification (8/9 pass):
 - `mother-run-test-child`: 3 facts written, dedup works on re-run
 - `mother-spawns-children`: native spawn + WASM forge both work
 - `mother-routes-facts`: facts in project events.db, `source_id=child:test-child`, `blake3:` hashes
-- `mother-validates-schemas`: bogus schema dropped with warning ([[commit-952068a2]])
+- `mother-validates-schemas`: bogus schema dropped with warning ([[commit-47c8db4e]])
 - `credentials-via-pipe`: Tier 2 audit warning verified; Tier 1 awaits [[spec-github-connector]]
 - `sandbox-enforcement`: macOS works with/without `--no-sandbox`
-- `wasm-routing-resolved`: DESIGN.md §5 + frozen legacy comment ([[commit-99e46707]])
+- `wasm-routing-resolved`: DESIGN.md §5 + frozen legacy comment ([[commit-47312339]])
 - `mother-status-works`: `patina mother sources` shows timestamp, count, status
 - `mother-run-github`: BLOCKED by [[spec-github-connector]]
 
@@ -65,10 +65,10 @@ Phase 4 — Spec closure:
 - [[spec-mother-broker]] split via `spec_split` — v1 archived at v0.39.3, [[spec-mother-broker-github]] drafted with `blocked_by: github-connector`
 
 Phase 5 — Hardening (outside-agent feedback):
-- [[commit-ecdc6b21]]: Added broker integration test to `pre-push-checks.sh` (step 6/7) — builds test-child from source, runs `patina mother run test --no-sandbox`, catches wire format drift at push time
-- [[commit-27b79f26]]: Added hint to `patina mother status` pointing to `patina mother sources`
-- [[commit-f7adeed7]]: Created [[spec-pipe-contract-safety]] (3 ECs) for shared wire format types
-- [[commit-69436085]]: Created beliefs [[cross-crate-json-contracts-need-shared-types]] and [[connection-secrets-live-in-global-vault]]
+- [[commit-e772ebad]]: Added broker integration test to `pre-push-checks.sh` (step 6/7) — builds test-child from source, runs `patina mother run test --no-sandbox`, catches wire format drift at push time
+- [[commit-5f07e7df]]: Added hint to `patina mother status` pointing to `patina mother sources`
+- [[commit-5ddea52d]]: Created [[spec-pipe-contract-safety]] (3 ECs) for shared wire format types
+- [[commit-389507d8]]: Created beliefs [[cross-crate-json-contracts-need-shared-types]] and [[connection-secrets-live-in-global-vault]]
 
 **Key decisions:**
 - Marked `credentials-via-pipe` as checked despite Tier 1 being untestable — SPEC itself says "Verified after github-connector"

--- a/layer/sessions/20260307-202447.md
+++ b/layer/sessions/20260307-202447.md
@@ -35,7 +35,7 @@ Tagged as: session-20260307-202447-claude-start
 **Git Activity:**
 - Commits this session: 7
 - Files changed: 7 (spec files, DESIGN.md, Cargo.lock/toml)
-- Last commit: [[commit-6b57501e]]
+- Last commit: [[commit-943c6558]]
 
 **Work completed — Phase 1-3 of session prompt:**
 
@@ -62,7 +62,7 @@ Phase 3 — GitHub Connector Analysis:
 - Method 2 (`plugins/forge/`): WASM plugin → direct events.db write (FROZEN LEGACY)
 - Method 3 (`github-connector`): native child → pipe/http → broker → events.db (TO BUILD)
 - Identified gap: DESIGN.md said `reqwest::blocking` but should use `io.get(url).send()` via pipe/http
-- Updated DESIGN.md [[commit-6b57501e]] with resolved decisions from outside agent feedback:
+- Updated DESIGN.md [[commit-943c6558]] with resolved decisions from outside agent feedback:
   - pipe/http instead of reqwest (no direct sockets)
   - Cursor via latest `updated_at` (no chrono dependency)
   - Crate at `children/github-connector/` as workspace member

--- a/layer/sessions/20260307-210903.md
+++ b/layer/sessions/20260307-210903.md
@@ -33,7 +33,7 @@ Tagged as: session-20260307-210903-claude-start
 
 **Git Activity:**
 - Commits this session: 6
-- Last commit: [[commit-d8d618e4]]
+- Last commit: [[commit-b7296513]]
 
 **Phase 1 — Read Code Before Write Code (14+ files):**
 - Read all migration sources: `plugins/forge/src/github.rs` (450 LOC), `plugins/forge/src/lib.rs`
@@ -46,31 +46,31 @@ Tagged as: session-20260307-210903-claude-start
 
 **Phase 2 — Build (4 of 6 commits):**
 
-Commit 1 [[commit-e051ad44]]: `github-connector: create binary crate with Child trait impl`
+Commit 1 [[commit-df5c03af]]: `github-connector: create binary crate with Child trait impl`
 - `children/github-connector/` with Cargo.toml, child.toml, src/main.rs
 - Added to workspace members in root Cargo.toml
 - Skeleton Child impl: capabilities, initialize, empty fetch
 
-Commit 2 [[commit-6b7abde6]]: `github-connector: migrate GitHub REST API client`
+Commit 2 [[commit-2472c539]]: `github-connector: migrate GitHub REST API client`
 - `src/github.rs` ported from `plugins/forge/src/github.rs` (450→478 LOC)
 - Translation: `host_http::get` → `io.get(url).send()`, `host_emit` → `io.emit()`, `Result<_,String>` → `Result<_,PipeError>`
 - HTTP error mapping per DESIGN.md §2: 401/403 body check for rate limit, 429 → RateLimited, 5xx → Transient
 - Cursor tracking: latest `updated_at` from fetched items, string passthrough (no chrono)
 - No reqwest — all HTTP proxied through Mother
 
-Commit 3 [[commit-017f45ea]]: `github-connector: add github.* schema definition`
+Commit 3 [[commit-cc4a3d0a]]: `github-connector: add github.* schema definition`
 - `children/github-connector/schema.toml` (ships with connector)
 - Installed locally to `.patina/schemas/github/` (gitignored)
 - github.issue + github.pr fact types, embedding offset_slot=6, FTS indexes
-- Promoted [[spec-github-connector]] draft → ready [[commit-57896c9a]]
+- Promoted [[spec-github-connector]] draft → ready [[commit-3139270c]]
 
-Commit 4 [[commit-b5147669]]: `github-connector: wire connection + source config`
+Commit 4 [[commit-2df969a6]]: `github-connector: wire connection + source config`
 - Created `~/.patina/connections/github.toml`: provider=github, credential=github-token, child=github-connector
 - Added `[sources.github]` to `.patina/sources.toml`: types=[issues,prs], params={owner,repo}
 - Installed binary to `~/.patina/children/github-connector/`
 - **Live test: `patina mother run github --no-sandbox`** — 15 issues + 87 PRs = 102 facts written to events.db, cursor=2026-03-02T04:56:47Z
 - All HTTP via pipe/http through Mother, 200 OK on every request
-- Promoted [[spec-github-connector]] ready → active [[commit-d8d618e4]]
+- Promoted [[spec-github-connector]] ready → active [[commit-b7296513]]
 
 **Phase 3 — Deletion deferred:**
 - Scoped forge entanglement: `src/forge/` provides types, detect(), writer used by `src/git/fork.rs`, `src/commands/repo/`, `src/commands/scrape/code/`

--- a/layer/sessions/20260307-214010.md
+++ b/layer/sessions/20260307-214010.md
@@ -38,7 +38,7 @@ Tagged as: session-20260307-214010-claude-start
 
 **Git Activity:**
 - Commits this session: 10
-- Last commit: [[commit-686f7448]]
+- Last commit: [[commit-94787579]]
 
 **Phase 1 — Read Code Before Write Code (16 files):**
 - Read all 3 anchoring values: [[dependable-rust]], [[unix-philosophy]], [[spec-driven-design]]
@@ -47,39 +47,39 @@ Tagged as: session-20260307-214010-claude-start
 
 **Phase 2 — Surgical Deletion (6 commits):**
 
-Commit 1 [[commit-1c9c27b0]]: `forge: move ForgeWriter to src/git/writer.rs`
+Commit 1 [[commit-eca08c67]]: `forge: move ForgeWriter to src/git/writer.rs`
 - Moved ForgeWriter trait, GitHubWriter, NoneWriter + helpers (227 LOC)
 - Updated imports in `src/git/fork.rs` and `src/commands/repo/internal.rs`
 - Rationale: git write ops (fork, create-repo) are a git concern, not data ingestion
 
-Commit 2 [[commit-cfae9b67]]: `forge: move scrape utilities to scrape/events.rs`
+Commit 2 [[commit-beb307bd]]: `forge: move scrape utilities to scrape/events.rs`
 - Created `src/commands/scrape/events.rs` (485 LOC) with:
   - Domain types: Issue, PullRequest, Comment, IssueState, PrState
   - Functions: insert_issues, insert_prs, project_from_events, create_materialized_views, populate_fts5_issues, populate_fts5_prs
 - Updated 4 consumers: extracted_data.rs, extract_v2.rs (6 call sites), code/mod.rs (2 call sites), repo/internal.rs
 - Changed scrape_github_issues() to no-op (github-connector handles via broker)
 
-Commit 3 [[commit-4347b396]]: `forge: delete scrape forge command (705 LOC)`
+Commit 3 [[commit-02135748]]: `forge: delete scrape forge command (705 LOC)`
 - Deleted `src/commands/scrape/forge/` directory
 - Removed execute_forge() + 5 helpers (resolve_repo_path, get_repo_spec, get_db_path, execute_forge_status, execute_forge_log, execute_forge_background, execute_forge_limited)
 - Removed Forge variant from ScrapeCommands CLI enum + match arm
 - Updated execute_rebuild() to skip forge step
 
-Commit 4 [[commit-74627052]]: `forge: delete src/forge/ (1,683 LOC)`
+Commit 4 [[commit-78b33241]]: `forge: delete src/forge/ (1,683 LOC)`
 - Deleted entire src/forge/ directory (8 files)
 - Removed `pub mod forge;` from `src/lib.rs`
 
-Commit 5 [[commit-2213556c]]: `forge: delete WASM plugin (640 LOC)`
+Commit 5 [[commit-00a08878]]: `forge: delete WASM plugin (640 LOC)`
 - Deleted `plugins/forge/` directory (3 files)
 - Removed from workspace members in `Cargo.toml`
 
-Commit 6 [[commit-df3716cb]]: `spec: mark github-connector ECs verified, amend plugins-forge EC`
+Commit 6 [[commit-f20eb158]]: `spec: mark github-connector ECs verified, amend plugins-forge EC`
 - Amended EC4 from "plugins-forge-coexists" to "plugins-forge-deleted"
 - Marked all 5 ECs checked: connector-speaks-pipe, emits-github-facts, src-forge-deleted, plugins-forge-deleted, mother-run-works
 
 **Phase 3 — Release + Cleanup:**
-- [[commit-a0449035]]: `release: v0.40.0` — [[spec-github-connector]] completed and archived
-- [[commit-686f7448]]: Removed 2 orphaned forge plugin manifest tests
+- [[commit-668b6b92]]: `release: v0.40.0` — [[spec-github-connector]] completed and archived
+- [[commit-94787579]]: Removed 2 orphaned forge plugin manifest tests
 - cargo fmt, Cargo.lock update
 
 **Phase 4 — Grep Sweep:**

--- a/layer/sessions/20260307-222328.md
+++ b/layer/sessions/20260307-222328.md
@@ -37,7 +37,7 @@ Tagged as: session-20260307-222328-claude-start
 ### 23:28 - Update (covering since 22:23)
 
 **Git Activity:**
-- Commits this session: 2 ([[commit-9811dddb]], [[commit-32e19082]])
+- Commits this session: 2 ([[commit-73f151bf]], [[commit-f5328b3c]])
 - Files changed: 2 (`DESIGN.md`, `SPEC.md`)
 - Last commit: 7 minutes ago
 
@@ -79,14 +79,14 @@ The github-connector emits `github.issue`/`github.pr` events to events.db, but `
 ### 23:41 - Update (covering since 23:28)
 
 **Git Activity:**
-- Commits this session: 5 ([[commit-2c810e42]], [[commit-fb15d2c5]], [[commit-b3d58578]], [[commit-9811dddb]], [[commit-32e19082]])
+- Commits this session: 5 ([[commit-70335d84]], [[commit-f8746c46]], [[commit-0f284b08]], [[commit-73f151bf]], [[commit-f5328b3c]])
 - Files changed: 9
 - Working tree: clean
 
 **Committed all changes (3 logical commits):**
-- [[commit-b3d58578]]: `audit: remove dead forge staging code and WASM tests` — 301 lines deleted from `src/commands/scrape/code/extract_v2.rs` and `src/plugin/internal/tests.rs`
-- [[commit-fb15d2c5]]: `spec: github-child-owns-forge` — filled in SPEC.md (6 ECs) and DESIGN.md (4 phases, history, key files, open questions)
-- [[commit-2c810e42]]: `layer: add session logs` — 4 session files from forge deletion work
+- [[commit-0f284b08]]: `audit: remove dead forge staging code and WASM tests` — 301 lines deleted from `src/commands/scrape/code/extract_v2.rs` and `src/plugin/internal/tests.rs`
+- [[commit-f8746c46]]: `spec: github-child-owns-forge` — filled in SPEC.md (6 ECs) and DESIGN.md (4 phases, history, key files, open questions)
+- [[commit-70335d84]]: `layer: add session logs` — 4 session files from forge deletion work
 
 **Wrote next-session prompt** for [[spec-github-child-owns-forge]] Phase 1: fix projection gap (~10 lines SQL in `src/commands/scrape/events.rs`), anchored in [[dependable-rust]], [[unix-philosophy]], [[spec-driven-design]].
 

--- a/layer/surface/epistemic/beliefs/specs-describe-current-code-not-aspirations.md
+++ b/layer/surface/epistemic/beliefs/specs-describe-current-code-not-aspirations.md
@@ -39,7 +39,7 @@ Spec EC text and verify fields must describe what the code does today, not what 
 
 - [[spec-pipe-native-transport]] EC3 — rewritten from "deny all outbound sockets" to "port 443 + DNS, tested via fork-based tests." Forward reference to pipe-mother-io for tightening.
 - [[spec-pipe-native-transport]] "Known Gap: Domain Enforcement" section — explicitly states the gap and names the fix, rather than pretending the gap doesn't exist.
-- [[commit-b5c527c5]] — corrected 3 specs that described future state as current.
+- [[commit-7f1cd08b]] — corrected 3 specs that described future state as current.
 
 ## Revision Log
 

--- a/resources/git/README.md
+++ b/resources/git/README.md
@@ -10,9 +10,11 @@ ln -sf ../../resources/git/post-commit.sh .git/hooks/post-commit
 ln -sf ../../resources/git/post-merge.sh .git/hooks/post-merge
 ```
 
+The pre-commit and pre-push hooks use exec-style delegation (see `.git/hooks/pre-commit` and `.git/hooks/pre-push`).
+
 Verify:
 ```bash
-ls -la .git/hooks/post-*
+ls -la .git/hooks/pre-commit .git/hooks/pre-push .git/hooks/post-*
 ```
 
 ## Install (other projects)

--- a/resources/git/pre-commit-checks.sh
+++ b/resources/git/pre-commit-checks.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+# Pre-commit checks for Patina - block large files before they enter history
+#
+# GitHub rejects files > 100MB. Catching at commit time avoids
+# costly filter-repo rewrites later.
+
+set -e
+
+MAX_SIZE_KB=10240  # 10MB — generous but well under GitHub's 100MB limit
+
+echo "🔍 Running pre-commit checks..."
+echo ""
+
+echo "📦 [1/1] Checking for large staged files (>${MAX_SIZE_KB}KB)..."
+large_files=()
+
+# Check staged files (added or modified), skip deletions
+for file in $(git diff --cached --name-only --diff-filter=d); do
+    # Get staged blob size (not working-tree size)
+    size=$(git cat-file -s "$(git ls-files -s "$file" | awk '{print $2}')" 2>/dev/null || echo 0)
+    size_kb=$((size / 1024))
+    if [ "$size_kb" -gt "$MAX_SIZE_KB" ]; then
+        large_files+=("$file (${size_kb}KB)")
+    fi
+done
+
+if [ ${#large_files[@]} -gt 0 ]; then
+    echo "   ❌ Large files detected — these would bloat git history:"
+    for f in "${large_files[@]}"; do
+        echo "      $f"
+    done
+    echo ""
+    echo "   Add to .gitignore or use Git LFS instead."
+    echo "   To bypass (if intentional): git commit --no-verify"
+    exit 1
+fi
+
+echo "   ✓ No large files"
+echo ""
+echo "✅ Pre-commit checks passed!"


### PR DESCRIPTION
## Summary
- Remapped 121 stale `[[commit-*]]` SHA references in layer/ after filter-repo history rewrite
- Added pre-commit hook to block files >10MB from entering git history (prevents future filter-repo needs)
- Updated git hooks README

## Test plan
- [x] Zero stale SHA references remaining after remap
- [x] Pre-commit hook fires on commit and passes
- [x] `cargo build --release` passes
- [x] Pre-push checks pass