### PR TITLE
chore(distribution): sync Homebrew checksums to v0.64.3 assets

### DIFF
--- a/packaging/homebrew/Formula/patina.rb
+++ b/packaging/homebrew/Formula/patina.rb
@@ -8,12 +8,12 @@ class Patina < Formula
 
   on_macos do
     url "https://github.com/NicabarNimble/patina/releases/download/v#{version}/patina-aarch64-apple-darwin.tar.gz"
-    sha256 "REPLACE_WITH_MACOS_ARM64_SHA256"
+    sha256 "6e5ca81f8ace8c354666e0fcd23f88db66376e2f99dd0aad9d32b0f961aa0b7e"
   end
 
   on_linux do
     url "https://github.com/NicabarNimble/patina/releases/download/v#{version}/patina-x86_64-unknown-linux-gnu.tar.gz"
-    sha256 "REPLACE_WITH_LINUX_X64_SHA256"
+    sha256 "3850a589879d0e238f515daf713b1f644742afa37357b209ffb6cb6a36693de0"
   end
 
   def install


### PR DESCRIPTION
## Summary

Follow-up distribution sync after #119 merge:

- Release assets for `v0.64.3` are now published (linux + macOS tarballs + `checksums.txt`).
- Wire Homebrew formula checksums to the published `v0.64.3` artifacts:
  - macOS arm64 sha256: `6e5ca81f8ace8c354666e0fcd23f88db66376e2f99dd0aad9d32b0f961aa0b7e`
  - linux x86_64 sha256: `3850a589879d0e238f515daf713b1f644742afa37357b209ffb6cb6a36693de0`

This unblocks both tap install verification and curl installer checksum validation against the same release payload.

## Validation

- [x] `ruby -c packaging/homebrew/Formula/patina.rb`
- [x] `bash -n install.sh`
- [x] `bash install.sh --version 0.64.3 --bin-dir <tmp>` (checksum verified, binary reports `patina-ai 0.64.3`)

## Notes

- `releases/latest` now resolves to `v0.64.3`, so stable channel curl installs target this version by default.
