### PR TITLE
Slate migration: spec/design cleanup and supporting beliefs

### DIFF
--- a/layer/core/beliefs/contracts-outlive-runtimes.md
+++ b/layer/core/beliefs/contracts-outlive-runtimes.md
@@ -1,0 +1,34 @@
+---
+type: belief
+id: contracts-outlive-runtimes
+status: active
+confidence: medium
+created: 2026-04-22
+evidence:
+  - layer/surface/build/feat/slate-pando-migration/SPEC.md
+  - layer/surface/build/feat/legacy-typed-bridge-seam/SPEC.md
+  - commit-2e3d04b2
+  - commit-98ed1113
+---
+
+# Contracts Outlive Runtimes
+
+Prioritize stable typed contracts and policy envelopes over runtime-specific wiring.
+Runtimes are expected to change; contracts must remain dependable.
+
+## Rule
+
+- Keep domain behavior at typed interface boundaries.
+- Allow runtime/adapter replacement behind those boundaries.
+- Preserve caller surface compatibility while internals migrate.
+
+## Why
+
+Runtime ecosystems move at different speeds. If runtime details leak into business behavior,
+migration cost explodes and safety guarantees drift.
+
+## Anchors in this repo
+
+- Slate migration kept `patina spec` user surface while routing internals to typed operations in [[slate-pando-migration]].
+- Typed route parity harness and routing hardening in [[commit-98ed1113]] and [[commit-2e3d04b2]].
+- Release continuity while migration progressed: [[tag-v0.64.1]], [[tag-v0.64.2]], [[tag-v0.64.3]].

--- a/layer/core/beliefs/control-plane-authority-distributed-execution.md
+++ b/layer/core/beliefs/control-plane-authority-distributed-execution.md
@@ -1,0 +1,31 @@
+---
+type: belief
+id: control-plane-authority-distributed-execution
+status: active
+confidence: medium
+created: 2026-04-22
+evidence:
+  - layer/surface/build/feat/child-construction-canon/SPEC.md
+  - layer/surface/build/feat/slate-pando-migration/SPEC.md
+  - commit-2e3d04b2
+---
+
+# Control Plane Authority, Distributed Execution
+
+Centralize discovery, policy, and conflict decisions in control plane; execute work at the owning child.
+
+## Rule
+
+- Control plane owns: registration, grants, policy, routing decisions.
+- Data plane owns: command execution in the specific child that implements capability.
+- Never force all execution through a single bridge path when direct typed routing is available.
+
+## Why
+
+This avoids central bottlenecks, preserves least-privilege boundaries, and keeps ownership explicit.
+
+## Anchors in this repo
+
+- Mother dispatch routes typed Slate operations to the owning child path in [[commit-2e3d04b2]].
+- MCT direction and child role separation tracked in [[child-construction-canon]] and [[slate-pando-migration]].
+- Current release lane where this pattern is active: [[tag-v0.64.3]].

--- a/layer/core/beliefs/explicit-fail-closed-over-hidden-fallbacks.md
+++ b/layer/core/beliefs/explicit-fail-closed-over-hidden-fallbacks.md
@@ -1,0 +1,34 @@
+---
+type: belief
+id: explicit-fail-closed-over-hidden-fallbacks
+status: active
+confidence: medium
+created: 2026-04-22
+evidence:
+  - layer/surface/build/feat/slate-pando-migration/SPEC.md
+  - layer/core/beliefs/temporal-layering-causes-drift.md
+  - commit-0cd5833e
+  - commit-2e3d04b2
+---
+
+# Explicit Fail-Closed Over Hidden Fallbacks
+
+When ownership is changing between systems, unsupported paths should fail explicitly rather than silently tunnel through compatibility backdoors.
+
+## Rule
+
+- If command is not owned/implemented on the active path, return a deterministic error.
+- Keep compatibility shims temporary, named, and scheduled for removal.
+- Prefer visible contract gaps over silent behavioral drift.
+
+## Why
+
+Hidden fallbacks create long-lived dual systems and make reliability claims unverifiable.
+Fail-closed behavior keeps migration debt visible and testable.
+
+## Anchors in this repo
+
+- Execute-path strictness and typed routing hardening in [[slate-pando-migration]] and [[commit-2e3d04b2]].
+- Response-shape parity cleanup to reduce hidden drift in [[commit-0cd5833e]].
+- This extends and operationalizes [[temporal-layering-causes-drift]].
+- Release anchors during this migration window: [[tag-v0.64.2]], [[tag-v0.64.3]].

--- a/layer/core/values/contract-first-execution.md
+++ b/layer/core/values/contract-first-execution.md
@@ -1,0 +1,20 @@
+---
+type: value
+id: contract-first-execution
+status: active
+entrenchment: very-high
+facets: [architecture, control-plane, contracts, wasi, component-model, sdk]
+references: [safety-boundaries, dependable-rust, unix-philosophy, spec-driven-design, sdk-vision-lock]
+created: 2026-04-21
+---
+# Contract-First Execution
+
+Separate authority from execution. Mother decides policy and routing, children execute typed WIT operations, and toys are explicit capabilities. Keep boundaries in the WASI component model: declared WIT worlds, declared imports, and `wasm32-wasip2` components.
+
+## Test
+
+Can you point to one Mother authority decision, one typed WIT operation boundary, and one explicit toy scope for this flow? If any is missing, the design is leaking authority or capability.
+
+## Consequence
+
+Control stays centralized while execution stays modular. New callers can be added without changing child behavior, and new children can be authored through the SDK without reopening architecture each session.

--- a/layer/sessions/20260424-063230-539313000.md
+++ b/layer/sessions/20260424-063230-539313000.md
@@ -1,0 +1,49 @@
+---
+type: session
+id: 20260424-063230-539313000
+runtime_id: 6ab390cd-8560-4381-b96f-a92290d446f2
+continuity_uid: 6ab390cd-8560-4381-b96f-a92290d446f2
+work_spec: unspecified
+title: pi session
+status: active
+llm: pi
+interface: pi
+created: 2026-04-24T10:32:30.539363+00:00
+updated: 2026-04-24T10:32:30.539363+00:00
+start_timestamp: 1777026750539
+source_log: /Users/nicabar/.pi/agent/sessions/--Users-nicabar-Projects-Sandbox-AI-RUST-patina--/2026-04-24T03-40-29-053Z_019dbd93-1ffd-779a-8e8f-472e2547e2e8.jsonl
+participants:
+- id: pi-3482
+  role: interface
+  interface: pi
+  interface_name: pi
+  display_name: nicabar
+  joined_at: 2026-04-24T10:32:30.539363+00:00
+interfaces:
+- pi
+git:
+  project_uid: 2bdc808e
+  branch: none
+  starting_commit: none
+  start_tag: session-20260424-063230-539313000-pi-start
+---
+
+## Previous Session Context
+<!-- AI: Summarize the last session from last-session.md -->
+
+## Goals
+- [ ] pi session
+
+## Activity Log
+### 06:32 - Session Start
+Session initialized with goal: pi session
+Working on branch: none
+Tagged as: session-20260424-063230-539313000-pi-start
+
+## Decisions
+
+## Evidence
+
+## Handoff
+
+## Outcome

--- a/layer/surface/build/feat/slate-pando-migration/DESIGN.md
+++ b/layer/surface/build/feat/slate-pando-migration/DESIGN.md
@@ -27,7 +27,13 @@ This design locks **parity-first** execution:
 
 Add a Slate WIT contract that avoids untyped `handle(action,payload)` and exposes typed command dispatch.
 
-Contract now includes per-command typed functions (`list-specs`, `next-specs`, `check/show/prompt/handoff/packet-spec`, `complete-spec`, `archive-spec`) while keeping `dispatch(command-json)` as transitional compatibility during migration.
+Contract now includes per-command typed functions (`list-specs`, `next-specs`, `check/show/prompt/handoff/packet-spec`, `complete-spec`, `archive-spec`).
+
+Current command ownership split is explicit:
+- Slate-owned now: `list`, `next`, `check`, `show`, `prompt`, `handoff`, `packet`, `complete`, `archive`.
+- Core-owned now: `create`, `ready`, `blocked`, `promote`, `abandon`, `pause`, `resume`, `block`, `split`, `history`, `rename`, `reopen`, `set`.
+
+`dispatch(command-json)` remains only as temporary bridge and should be removed once non-Slate commands fail explicitly in execute mode.
 
 ## Slice progress
 
@@ -47,14 +53,17 @@ Contract now includes per-command typed functions (`list-specs`, `next-specs`, `
    - `list/next/show/check/prompt/handoff/packet` implemented via filesystem/frontmatter/design parsing in Slate child.
    - Observe-mode fixture diff harness now enforces deterministic builtin==slate-probe equality over read-only command set.
    - Execute payload contracts are being normalized to builtin response shapes to avoid child-only output drift.
-2. Expand `patina:git` contract for mutate/release parity.
+2. Remove hidden JSON fallback bridge.
+   - Mother router should return explicit execute-mode errors for non-Slate commands (no `dispatch` tunnel).
+   - Then remove `dispatch` from WIT contract/allowlist and switch Slate ingress to `wit-only`.
+3. Expand `patina:git` contract for mutate/release parity.
    - Started: added `create-tag-at`, `status-porcelain`, `add-paths`, `is-clean-tracked`,
      `commits-behind-upstream`, `is-diverged` to WIT + host bindings.
    - Extended with `remove-paths` for tracked deletion/archive workflows.
-3. Execute mutate parity (`complete`/`archive`) in Slate.
+4. Execute mutate parity (`complete`/`archive`) in Slate.
    - In progress: git-backed archive path is implemented and `complete` now executes Cargo version-bump release flow for `feat`/`fix`/`refactor` and `--major`.
    - Remaining parity: tighten safeguards/output equivalence and fixture-lock behavior for all complete/archive variants.
-3. Move git toy toward foldered multi-file WIT package layout (WASI-like structure) with tooling support.
+5. Move git toy toward foldered multi-file WIT package layout (WASI-like structure) with tooling support.
 
 ## Safety
 

--- a/layer/surface/build/feat/slate-pando-migration/SPEC.md
+++ b/layer/surface/build/feat/slate-pando-migration/SPEC.md
@@ -3,7 +3,7 @@ type: feat
 id: slate-pando-migration
 status: active
 created: 2026-04-07
-updated: 2026-04-21
+updated: 2026-04-22
 beliefs:
   - "[[spec-driven-design]]"
   - "[[safety-boundaries]]"
@@ -25,7 +25,11 @@ related:
   - layer/surface/build/feat/spec-release-pr-automation/SPEC.md
 exit_criteria:
   - id: sp1-parity-command-surface
-    text: "Slate exposes a 1:1 parity command surface for current `patina spec` flows (`list`, `next`, `show`, `check`, `prompt`, `handoff`, `packet`, `complete`, `archive`) with equivalent outputs for existing fixtures."
+    text: "Slate exposes a 1:1 parity command surface for current routed `patina spec` flows (`list`, `next`, `show`, `check`, `prompt`, `handoff`, `packet`, `complete`, `archive`) with equivalent outputs for existing fixtures."
+    checked: false
+
+  - id: sp1b-command-gap-contract
+    text: "For `spec` commands not yet owned by Slate (`create`, `ready`, `blocked`, `promote`, `abandon`, `pause`, `resume`, `block`, `split`, `history`, `rename`, `reopen`, `set`), behavior is explicit and fail-closed in Slate execute mode (no hidden JSON fallback)."
     checked: false
 
   - id: sp2-full-wit-child
@@ -134,7 +138,10 @@ Primary principle: **parity first, innovation second**.
 - `patina spec` now resolves backend mode from env or project manifest (`[spec] mode = off|observe|execute`).
 - Observe mode preserves builtin output and appends `backend.slate_probe` metadata.
 - Execute mode routes through typed `slate-manager` call path and fails closed if child is missing/unavailable.
-- Mother now maps supported `spec` commands onto per-command typed Slate operations (`patina:slate/control.*-specs|*-spec`) instead of always tunneling command JSON through `dispatch`.
+- Mother maps supported `spec` commands onto per-command typed Slate operations (`patina:slate/control.*-specs|*-spec`) instead of always tunneling command JSON through `dispatch`.
+- Command-surface delta is now explicit:
+  - Routed to typed Slate today: `list`, `next`, `check`, `show`, `prompt`, `handoff`, `packet`, `complete`, `archive`.
+  - Still core-owned (not Slate-owned): `create`, `ready`, `blocked`, `promote`, `abandon`, `pause`, `resume`, `block`, `split`, `history`, `rename`, `reopen`, `set`.
 - Execute mode is strict fail-closed: when Slate reports scaffold/not-implemented (or any execute-path error), Mother returns an error instead of silently falling back.
 - Added routing smoke coverage in `src/commands/spec/mod.rs` and daemon dispatch tests in `src/commands/mother/daemon/tests/mod.rs`.
 - Started Option A git-toy expansion for Slate mutate/release parity (`create-tag-at`, `status-porcelain`, `add-paths`, `is-clean-tracked`, `commits-behind-upstream`, `is-diverged`) in WIT + host bindings.
@@ -171,16 +178,20 @@ Defaults must replicate current core behavior so projects can opt in without ext
 ## Execution order (implementation slices)
 
 1. **Parity contract freeze**
-   - Lock command/JSON/output fixtures for current `spec` flows.
+   - Lock command/JSON/output fixtures for current routed `spec` flows.
 2. **Full-WIT Slate child scaffold**
    - Add child contract + runtime wiring + minimal toy grants.
 3. **Observe mode routing**
    - `patina spec` can run Slate shadow path and diff outputs.
 4. **Execute mode routing**
    - Enable side effects behind opt-in.
-5. **Per-project policy mapping**
+5. **Command-gap contract hardening**
+   - Make non-Slate `spec` commands explicit in execute mode (clear error contract).
+   - Remove hidden fallback path (`patina:slate/control.dispatch`) once Mother/router behavior is explicit.
+   - Flip `children/slate-manager/child.toml` to `wit-only` after fallback removal.
+6. **Per-project policy mapping**
    - Add CI/PR customization knobs.
-6. **Default-switch readiness review**
+7. **Default-switch readiness review**
    - Keep `spec` compat path until parity criteria stay green across fixtures.
 
 ## Verification


### PR DESCRIPTION
## Summary
- refine `slate-pando-migration` spec/design details
- add supporting core beliefs/value docs:
  - `contracts-outlive-runtimes`
  - `control-plane-authority-distributed-execution`
  - `explicit-fail-closed-over-hidden-fallbacks`
  - `contract-first-execution`
- archive session artifact: `layer/sessions/20260424-063230-539313000.md`

## Why
- tighten migration guidance and preserve decision context in core layer artifacts
- keep provenance linked through beliefs/values/session updates

## Validation
- pre-push Tier 1 structural checks passed
- Tier 2 cargo lane skipped (no cargo-impacting files)
